### PR TITLE
pulseaudio: fix recursive dependencies

### DIFF
--- a/sound/pulseaudio/Makefile
+++ b/sound/pulseaudio/Makefile
@@ -84,7 +84,7 @@ endef
 define Package/pulseaudio-tools
   SECTION:=sound
   CATEGORY:=Sound
-  DEPENDS:=+libsndfile +pulseaudio
+  DEPENDS:=+libsndfile pulseaudio
   TITLE:=Tools for Pulseaudio
   URL:=http://www.pulseaudio.org
   VARIANT:=noavahi
@@ -93,7 +93,7 @@ endef
 define Package/pulseaudio-profiles
   SECTION:=sound
   CATEGORY:=Sound
-  DEPENDS:=+pulseaudio
+  DEPENDS:=pulseaudio
   TITLE:=Profiles for Pulseaudio
   URL:=http://www.pulseaudio.org
 endef


### PR DESCRIPTION
After this pr https://github.com/coolsnowwolf/lede/pull/2690 ，there will be a problem like this:
tmp/.config-package.in:84257:error: recursive dependency detected!
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
tmp/.config-package.in:84257:   symbol PACKAGE_pulseaudio-profiles depends on PACKAGE_pulseaudio-profiles
tmp/.config-package.in:84273:error: recursive dependency detected!
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
tmp/.config-package.in:84273:   symbol PACKAGE_pulseaudio-tools depends on PACKAGE_pulseaudio-tools