### PR TITLE
libuv: bump to v1.34.2

### DIFF
--- a/libs/libuv/Makefile
+++ b/libs/libuv/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libuv
-PKG_VERSION:=1.32.0
+PKG_VERSION:=1.34.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://dist.libuv.org/dist/v$(PKG_VERSION)/
-PKG_HASH:=203927683d53d1b82eee766c8ffecfa8ed0e392679c15d5ad3a23504eda0ed1f
+PKG_HASH:=65d93b4504ef5f3ec784c0c186f4ba8abd1031292c7f15dda8111d7e319adf46
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-v$(PKG_VERSION)
 
 PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>


### PR DESCRIPTION
This fix commit 49a10f02d88e6cee28af6f60e36ea628b6b607a3 compile error.