### PR TITLE
缓存结果，节省io

### DIFF
--- a/net/ddns-scripts/files/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/dynamic_dns_functions.sh
@@ -80,7 +80,12 @@ WGET_SSL=$(which wget-ssl)
 CURL=$(which curl)
 
 # CURL_PROXY not empty then Proxy support available
-CURL_PROXY=$(find /lib /usr/lib -name libcurl.so* -exec strings {} 2>/dev/null \; | grep -im1 "all_proxy")
+if [ -f /tmp/vCURL_PROXY ]; then
+	CURL_PROXY=$(cat /tmp/vCURL_PROXY);
+else
+	CURL_PROXY=$(find /lib /usr/lib -name libcurl.so* -exec strings {} 2>/dev/null \; | grep -im1 "all_proxy")
+	echo $CURL_PROXY>/tmp/vCURL_PROXY
+fi
 
 UCLIENT_FETCH=$(which uclient-fetch)
 


### PR DESCRIPTION
每次都要find /lib，挺占cpu时间的

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
