### PR TITLE
docker-ce: fix build failure caused by depend missing

### DIFF
--- a/utils/containerd/Makefile
+++ b/utils/containerd/Makefile
@@ -1,15 +1,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=containerd
-PKG_VERSION:=1.2.10
+PKG_VERSION:=1.2.13
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/containerd/containerd/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=a0965e1492fca558629826f1aa89a9675de3d451cec67540400b30c0bf6ac387
-PKG_SOURCE_VERSION:=b34a5c8af56e510852c35414db4c1f4fa6172339
+PKG_HASH:=0811057ab67b78ce911416e793edaeb14b3f1e105d67b8e67b6302e0eab572e4
+PKG_SOURCE_VERSION:=7ad184331fa3e55e52b890ea95e65ba581ae3429
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 
@@ -39,7 +39,7 @@ define Package/containerd
   CATEGORY:=Utilities
   TITLE:=containerd container runtime
   URL:=https://containerd.io/
-  DEPENDS:=$(GO_ARCH_DEPENDS) @HAS_FPU @TARGET_x86_64||arm||aarch64 +btrfs-progs +runc +CONTAINERD_SECCOMP:libseccomp
+  DEPENDS:=$(GO_ARCH_DEPENDS) @(aarch64||arm||x86_64) +btrfs-progs +runc +CONTAINERD_SECCOMP:libseccomp
   MENU:=1
 endef
 
@@ -49,14 +49,7 @@ endef
 
 GO_PKG_INSTALL_ALL:=1
 MAKE_PATH:=$(GO_PKG_WORK_DIR_NAME)/build/src/$(GO_PKG)
-MAKE_VARS += \
-	GOPATH=$(GO_PKG_BUILD_DIR) \
-	GOCACHE=$(GO_PKG_CACHE_DIR) \
-	GOTMPDIR=$(GO_PKG_TMP_DIR) \
-	GOROOT_FINAL=$(GO_TARGET_ROOT) \
-	CC=$(TARGET_CC) \
-	CXX=$(TARGET_CXX) \
-	$(call GoPackage/Environment)
+MAKE_VARS += $(call GoPackage/Environment)
 MAKE_FLAGS += \
 	DESTDIR="$(PKG_INSTALL_DIR)" \
 	VERSION=$(PKG_VERSION) \

--- a/utils/docker-ce/Config.in
+++ b/utils/docker-ce/Config.in
@@ -1,7 +1,7 @@
 menu "Kernel features for Docker"
 	config DOCKER_KERNEL_OPTIONS
 		bool "Enable Basic kernel support for Docker"
-		default n
+		default y
 		select KERNEL_CGROUPS
 		select KERNEL_CGROUP_CPUACCT
 		select KERNEL_CGROUP_SCHED

--- a/utils/libnetwork/Makefile
+++ b/utils/libnetwork/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libnetwork
-PKG_RELEASE:=2
+PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
@@ -12,9 +12,9 @@ GO_PKG_BUILD_PKG:= \
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://$(GO_PKG)
-PKG_SOURCE_VERSION:=45c710223c5fbf04dc3028b9a90b51892e36ca7f
-PKG_SOURCE_DATE:=2019-10-15
-PKG_MIRROR_HASH:=776d0f6e870ce4432cc09ba75f3b075ef29cd797dcf9d631d726df4a2b7cbf28
+PKG_SOURCE_VERSION:=9fd385be8302dbe1071a3ce124891893ff27f90f
+PKG_SOURCE_DATE:=2020-01-03
+PKG_MIRROR_HASH:=16cea9d9978b11869029bc9ae0da533c2d7fdf4b9c1f7905bf6c98f443347831
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 
@@ -29,7 +29,7 @@ define Package/libnetwork
   CATEGORY:=Utilities
   TITLE:=networking for containers
   URL:=https://github.com/docker/libnetwork
-  DEPENDS:=$(GO_ARCH_DEPENDS) @HAS_FPU @TARGET_x86_64||arm||aarch64
+  DEPENDS:=$(GO_ARCH_DEPENDS) @(aarch64||arm||x86_64)
 endef
 
 define Package/libnetwork/description

--- a/utils/runc/Makefile
+++ b/utils/runc/Makefile
@@ -1,18 +1,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=runc
-PKG_VERSION:=1.0.0-rc8+91-3e425f80
+PKG_VERSION:=1.0.0-rc10
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/opencontainers/runc
-PKG_MIRROR_HASH:=361658b3c61b9c727091aa10ba693f234a64aae592bb683005244a22e2778cfc
-PKG_HASH:=efe4ff9bbe49b19074346d65c914d809c0a3e90d062ea9619fe240f931f0b700
-PKG_SOURCE_VERSION:=3e425f80a8c931f88e6d94a8c831b9d5aa481657
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_DATE:=2019-10-15
+PKG_SOURCE_URL:=https://codeload.github.com/opencontainers/runc/tar.gz/v${PKG_VERSION}?
+PKG_HASH:=6b44985023347fb9c5a2cc6f761df8c41cc2c84a7a68a6e6acf834dff6653a9a
+PKG_SOURCE_VERSION:=dc9208a3303feef5b3839f4323d9beb36df0a9dd
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 
@@ -42,7 +39,7 @@ define Package/runc
   CATEGORY:=Utilities
   TITLE:=runc container runtime
   URL:=https://www.opencontainers.org/
-  DEPENDS:=$(GO_ARCH_DEPENDS) @HAS_FPU @TARGET_x86_64||arm||aarch64 +RUNC_SECCOMP:libseccomp
+  DEPENDS:=$(GO_ARCH_DEPENDS) @(aarch64||arm||x86_64) +RUNC_SECCOMP:libseccomp
   MENU:=1
 endef
 
@@ -52,14 +49,7 @@ endef
 
 GO_PKG_INSTALL_ALL:=1
 MAKE_PATH:=$(GO_PKG_WORK_DIR_NAME)/build/src/$(GO_PKG)
-MAKE_VARS += \
-	GOPATH=$(GO_PKG_BUILD_DIR) \
-	GOCACHE=$(GO_PKG_CACHE_DIR) \
-	GOTMPDIR=$(GO_PKG_TMP_DIR) \
-	GOROOT_FINAL=$(GO_TARGET_ROOT) \
-	CC=$(TARGET_CC) \
-	CXX=$(TARGET_CXX) \
-	$(call GoPackage/Environment)
+MAKE_VARS += $(call GoPackage/Environment)
 MAKE_FLAGS += \
 	COMMIT=$(PKG_SOURCE_VERSION)
 


### PR DESCRIPTION
fix pull request #56 from hyird/master

containerd: bump to 7ad184331fa3e55e52b890ea95e65ba581ae3429
libnetwork: bump to 9fd385be8302dbe1071a3ce124891893ff27f90f
runc: bump to dc9208a3303feef5b3839f4323d9beb36df0a9dd
