### PR TITLE
forked-daapd: fix compile error with ttyd

### DIFF
--- a/sound/forked-daapd/Makefile
+++ b/sound/forked-daapd/Makefile
@@ -35,7 +35,7 @@ URL:=https://github.com/ejurgensen/forked-daapd
 DEPENDS:=+libgpg-error +libgcrypt +libgdbm +zlib +libexpat +libunistring \
 	+libevent2 +libdaemon +libantlr3c +confuse +libopus +alsa-lib +libffmpeg-full \
 	+mxml +libavahi-client +sqlite3-cli +libplist +libcurl +libjson-c \
-	+libprotobuf-c +libgnutls +libsodium +libwebsockets $(ICONV_DEPENDS)
+	+libprotobuf-c +libgnutls +libsodium +libwebsockets-full $(ICONV_DEPENDS)
 endef
 
 define Package/forked-daapd/description
@@ -58,7 +58,7 @@ CONFIGURE_ARGS += \
 	--enable-webinterface \
 	--disable-spotify \
 	--with-libplist \
-	--with-libwebsockets \
+	--with-libwebsockets-full \
 	--with-alsa \
 	--without-pulseaudio \
 	--without-libevent_pthreads


### PR DESCRIPTION
This commit fixes: 
When the ttyd and forked-daapd are both selected, there will be some error messages appearing as follows.
`* check_data_file_clashes: Package libwebsockets-openssl wants to install file /home/runner/work/openwrt/openwrt/openwrt/build_dir/target-x86_64_musl/root-x86/usr/lib/libwebsockets.so
  But that file is already provided by package  * libwebsockets-full`