### PR TITLE
https-dns-proxy: do not boot on startup

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -42,4 +42,11 @@ define Package/https-dns-proxy/install
 	$(INSTALL_CONF) ./files/https-dns-proxy.config $(1)/etc/config/https-dns-proxy
 endef
 
+define Package/https-dns-proxy/postinst
+#!/bin/sh
+/etc/init.d/https-dns-proxy disable 
+/etc/init.d/https-dns-proxy stop
+exit 0
+endef
+
 $(eval $(call BuildPackage,https-dns-proxy))


### PR DESCRIPTION
只要选了开机就会自启 添加dnsmasq转发。得默认关了
Luci 也是控制init.d enbale disable 默认关闭不影响