### PR TITLE
minidlna: fix GCC 10 multiple def compilation error

### DIFF
--- a/multimedia/minidlna/patches/999-05-fix-setjmp-buffer-multiple-def.patch
+++ b/multimedia/minidlna/patches/999-05-fix-setjmp-buffer-multiple-def.patch
@@ -1,0 +1,22 @@
+--- a/image_utils.c
++++ b/image_utils.c
+@@ -190,7 +190,7 @@ jpeg_memory_src(j_decompress_ptr cinfo,
+ 	src->pub.bytes_in_buffer = bufsize;
+ }
+
+-jmp_buf setjmp_buffer;
++static jmp_buf setjmp_buffer;
+ /* Don't exit on error like libjpeg likes to do */
+ static void
+ libjpeg_error_handler(j_common_ptr cinfo)
+--- a/metadata.c
++++ b/metadata.c
+@@ -502,7 +502,7 @@ GetAudioMetadata(const char *path, const
+ }
+
+ /* For libjpeg error handling */
+-jmp_buf setjmp_buffer;
++static jmp_buf setjmp_buffer;
+ static void
+ libjpeg_error_handler(j_common_ptr cinfo)
+ {


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
