### PR TITLE
zerotier: bump to 1.6.2

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zerotier
-PKG_VERSION:=1.4.6
-PKG_RELEASE:=3
+PKG_VERSION:=1.6.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerotier/ZeroTierOne/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=d1a0eeb03acfa446f67adf5901902d17de14b4648c21e160024acf476e3d4fba
+PKG_HASH:=c8087b26c1191d36fda004b42cdfed31042cafd8586e49015586eef786f2c9a5
 PKG_BUILD_DIR:=$(BUILD_DIR)/ZeroTierOne-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>


### PR DESCRIPTION
<div class="markdown-body">
    <p><font style="vertical-align: inherit;"><font style="vertical-align: inherit;">1.6.0版是主要版本，其中包含了仍在开发中的2.0分支的反向移植功能。</font><font style="vertical-align: inherit;">它还解决了许多问题。</font></font></p>
<p><font style="vertical-align: inherit;"><font style="vertical-align: inherit;">新功能和改进（包括1.5.0中列出的功能）：</font></font></p>
<ul>
<li><strong><font style="vertical-align: inherit;"></font></strong><font style="vertical-align: inherit;"><font style="vertical-align: inherit;">通过通用二进制文件的</font><strong><font style="vertical-align: inherit;">Apple Silicon</font></strong><font style="vertical-align: inherit;">（MacOS ARM64）本机支持。</font><font style="vertical-align: inherit;">ZeroTier现在需要构建最新的Xcode。</font></font></li>
<li><strong><font style="vertical-align: inherit;"><font style="vertical-align: inherit;">Linux性能改进</font></font></strong><font style="vertical-align: inherit;"><font style="vertical-align: inherit;">，使多核系统上的tun / tap I / O</font><strong><font style="vertical-align: inherit;">性能提高</font></strong><font style="vertical-align: inherit;">了多达25％。</font></font></li>
<li><strong><font style="vertical-align: inherit;"><font style="vertical-align: inherit;">多路径支持</font></font></strong><font style="vertical-align: inherit;"><font style="vertical-align: inherit;">，其模式遵循Linux内核的绑定驱动程序。</font><font style="vertical-align: inherit;">这包括具有快速故障转移和负载平衡的主动-被动和主动-主动模式。</font><font style="vertical-align: inherit;">参见手册第2.1.5节。</font></font></li>
<li><strong><font style="vertical-align: inherit;"><font style="vertical-align: inherit;">DNS配置</font></font></strong><font style="vertical-align: inherit;"><font style="vertical-align: inherit;">从网络控制器到终端节点的推送，并具有是否允许推送的本地可配置权限。</font></font></li>
<li><strong><font style="vertical-align: inherit;"><font style="vertical-align: inherit;">AES-GMAC-SIV</font></font></strong><font style="vertical-align: inherit;"><font style="vertical-align: inherit;">加密模式，在支持AES加速的硬件上比旧的Salsa20 / 12-Poly1305模式更安全，并且速度更快。</font><font style="vertical-align: inherit;">这实际上包括所有X86-64芯片和大多数ARM64。</font><font style="vertical-align: inherit;">此模式基于AES-SIV，并已由Trail of Bits审核，以确保等效于安全性。</font></font></li>
</ul>
<p><font style="vertical-align: inherit;"><font style="vertical-align: inherit;">Bug修复：</font></font></p>
<ul>
<li><strong><font style="vertical-align: inherit;"><font style="vertical-align: inherit;">托管路由分配修复程序</font></font></strong><font style="vertical-align: inherit;"><font style="vertical-align: inherit;">可消除Linux上缺少的路由，以及我们认为是MacOS上零星的CPU高使用率的根源。</font></font></li>
<li><strong><font style="vertical-align: inherit;"><font style="vertical-align: inherit;">挂起关机</font></font></strong><font style="vertical-align: inherit;"><font style="vertical-align: inherit;">问题应该得到解决。</font></font></li>
<li><strong><font style="vertical-align: inherit;"><font style="vertical-align: inherit;">零星的多播中断</font></font></strong><font style="vertical-align: inherit;"><font style="vertical-align: inherit;">应该得到解决。</font></font></li>
</ul>
<p><font style="vertical-align: inherit;"><font style="vertical-align: inherit;">已知的剩余问题：</font></font></p>
<ul>
<li><font style="vertical-align: inherit;"><font style="vertical-align: inherit;">在32位ARM，PowerPC（32或64）或MIPS（32或64）系统上尚不支持AES硬件加速。</font><font style="vertical-align: inherit;">当前支持带有加密扩展的X86-64和ARM64 / AARCH64。</font></font></li>
</ul>
  </div>