### PR TITLE
docker-ce: fix vars order

### DIFF
--- a/utils/docker-ce/Makefile
+++ b/utils/docker-ce/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker-ce
 PKG_VERSION:=19.03.12
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=components/cli/LICENSE components/engine/LICENSE
 
@@ -30,7 +30,6 @@ PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1
 
 GO_PKG:=github.com/docker
-GO_PKG_BUILD_VARS += GO111MODULE=auto
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
@@ -84,6 +83,7 @@ define Build/Configure
 	$(LN) $(PKG_BUILD_DIR)/engine $(GO_PKG_BUILD_DIR)/src/$(GO_PKG)/docker
 endef
 
+GO_PKG_BUILD_VARS += GO111MODULE=auto
 ifeq ($(CONFIG_DOCKER_SECCOMP),y)
 BUILDTAGS:=seccomp
 else


### PR DESCRIPTION
GO_PKG_BUILD_VARS should be put behind golang-package.mk,
otherwise it will be overridden.

Fixes: coolsnowwolf/lede#6477

Signed-off-by: Tianling Shen <cnsztl@immortalwrt.org>