### PR TITLE
Use python3

### DIFF
--- a/devel/meson/Makefile
+++ b/devel/meson/Makefile
@@ -11,7 +11,7 @@ PKG_MAINTAINER:=Andre Heider <a.heider@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=COPYING
 
-HOST_BUILD_DEPENDS:=ninja/host
+HOST_BUILD_DEPENDS:=ninja/host python3/host
 
 include ../../lang/python/pypi.mk
 include $(INCLUDE_DIR)/host-build.mk

--- a/devel/meson/meson.mk
+++ b/devel/meson/meson.mk
@@ -37,7 +37,7 @@ MESON_VARS:=
 MESON_ARGS:=
 
 define Meson
-	$(2) $(STAGING_DIR_HOST)/bin/$(PYTHON) $(MESON_DIR)/meson.py $(1)
+	$(2) $(HOST_PYTHON3_BIN) $(MESON_DIR)/meson.py $(1)
 endef
 
 define Meson/CreateNativeFile


### PR DESCRIPTION
Maintainer: neheb 125f6ff9ec01c57e0cf57b042b95884f160cf48f
Compile tested: Newifi OpenWrt R21.2.1 
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
It should use python3 for pathlib
