### PR TITLE
try to fix #issue-909935861

### DIFF
--- a/libs/xr_usb_serial_common/Makefile
+++ b/libs/xr_usb_serial_common/Makefile
@@ -2,19 +2,17 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=usb-serial-xr_usb_serial_common
-PKG_VERSION:=1a
-PKG_RELEASE=1
+PKG_SOURCE_DATE:=2017-08-01
+PKG_SOURCE_VERSION:=b8dad8cf15de160afbd9989f880dc74b921a857b
+PKG_RELEASE:=2
 
-PKG_LICENSE:=GPLv2
-PKG_LICENSE_FILES:=
-
-PKG_SOURCE_URL:=https://github.com/kasbert/epsolar-tracer
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=8c21f4afdfd6acd77b6adad59a4dabe5cbf2b947
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.xz
+PKG_SOURCE_URL:=https://github.com/kasbert/epsolar-tracer
+PKG_MIRROR_HASH:=2cf23fec2625480bb4a630f96cd172219d401bd3cf90943394504ea0ba814faf
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=LICENSE
 PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk

--- a/libs/xr_usb_serial_common/patches/0001-common.c-fix-kernel-5.10-builds-with-CONFIG_PM-enabl.patch
+++ b/libs/xr_usb_serial_common/patches/0001-common.c-fix-kernel-5.10-builds-with-CONFIG_PM-enabl.patch
@@ -1,0 +1,48 @@
+From e4d127ddc83c5fbd93b9c8e2e4fe63b820ac28b6 Mon Sep 17 00:00:00 2001
+From: David Bauer <mail@david-bauer.net>
+Date: Sat, 22 May 2021 10:37:06 +0200
+Subject: [PATCH] common.c: fix kernel 5.10 builds with CONFIG_PM enabled
+
+Building the xr_usb_serial module fails for Kenel 5.10 with CONFIG_PM
+enabled:
+
+xr_usb_serial_common.c:1574:15: error: 'ASYNCB_INITIALIZED' undeclared
+(first use in this function); did you mean 'RCU_INITIALIZER'?
+
+Use tty_port_initialized in order to determine the status of the TTY
+port. This is compatible with Kernel 5.10 and at least Kernel 5.4.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+---
+ xr_usb_serial_common-1a/xr_usb_serial_common.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+--- a/xr_usb_serial_common-1a/xr_usb_serial_common.c
++++ b/xr_usb_serial_common-1a/xr_usb_serial_common.c
+@@ -1571,7 +1571,7 @@ static int xr_usb_serial_suspend(struct
+ 	if (cnt)
+ 		return 0;
+ 
+-	if (test_bit(ASYNCB_INITIALIZED, &xr_usb_serial->port.flags))
++	if (tty_port_initialized(&xr_usb_serial->port))
+ 		stop_data_traffic(xr_usb_serial);
+ 
+ 	return 0;
+@@ -1592,7 +1592,7 @@ static int xr_usb_serial_resume(struct u
+ 	if (cnt)
+ 		return 0;
+ 
+-	if (test_bit(ASYNCB_INITIALIZED, &xr_usb_serial->port.flags)) {
++	if (tty_port_initialized(&xr_usb_serial->port)) {
+ 		rv = usb_submit_urb(xr_usb_serial->ctrlurb, GFP_NOIO);
+ 
+ 		spin_lock_irq(&xr_usb_serial->write_lock);
+@@ -1623,7 +1623,7 @@ static int xr_usb_serial_reset_resume(st
+ {
+ 	struct xr_usb_serial *xr_usb_serial = usb_get_intfdata(intf);
+     struct tty_struct *tty;
+-	if (test_bit(ASYNCB_INITIALIZED, &xr_usb_serial->port.flags)){
++	if (tty_port_initialized(&xr_usb_serial->port)){
+ #if LINUX_VERSION_CODE > KERNEL_VERSION(3, 9, 0)	
+ 	tty_port_tty_hangup(&xr_usb_serial->port, false);
+ #else


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
fix the error corresponding to https://github.com/openwrt/packages/commit/69cf7836df9e226b4d596d057ca6ad846201e0d0,

xr_usb_serial_common.c:1574:15: error: 'ASYNCB_INITIALIZED' undeclared
(first use in this function); did you mean 'RCU_INITIALIZER'?

Use tty_port_initialized in order to determine the status of the TTY
port. This is compatible with Kernel 5.10 and at least Kernel 5.4.
