### PR TITLE
Aria2:Fix download errors

### DIFF
--- a/net/aria2/Config.in
+++ b/net/aria2/Config.in
@@ -3,7 +3,7 @@ menu "Aria2 Configuration"
 
 choice
 	prompt "SSL Library"
-	default ARIA2_OPENSSL
+	default ARIA2_GNUTLS
 
 config ARIA2_OPENSSL
 	bool "OpenSSL"


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
when download anything from https://cn.download.nvidia.com/***,aria2 return error code 1:ssl/tls handshake failure: protocol error.