### PR TITLE
Privoxy: add missing option

### DIFF
--- a/net/privoxy/files/privoxy.config
+++ b/net/privoxy/files/privoxy.config
@@ -42,3 +42,6 @@ config	privoxy	'privoxy'
 	option	debug_1024	'0'
 	option	debug_4096	'1'
 	option	debug_8192	'1'
+
+config system 'system'
+        option boot_delay '10'


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
Privoxy: add missing option