### PR TITLE
docker-compose: Update to version 2.2.2

### DIFF
--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=compose
-PKG_VERSION:=2.2.0
+PKG_VERSION:=2.2.2
 PKG_RELEASE:=$(AUTORELEASE)
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/docker/compose/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=5699734a4625507cf3e2382e056a0ff7ec60c9e1d654d8c7d93baf844313bcf9
+PKG_HASH:=001cf72f6bc8a8c43d100389e0bbd3d4d5f5c523f4e3f7ddd53f6a4cd2d6cb18
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 


### PR DESCRIPTION
What's Changed:

 - Return an error when failing to list containers by @ulyssessouza

 - compose logs to notify printer about container lifecycle events by
 @ndeloof

 - Turn external volume usage into a warning instead of erroring by
 @ulyssessouza

 - Use filepath instead of path to check if the dockerfile path is
 abolute or not by @glours

 - Upgrade version of opencontainers/image-spec (security issue) by
 @glours

 - Merge and fix Convert function from docker/compose-switch by
 @ulyssessouza

 - Fix to use Key instead of Service for graph updates by @Mygao

 - Fix links resolution by @ulyssessouza

 - Don't check compose labels on external volumes by @ndeloof

 - Refactoring variable name by @ulyssessouza

 - Add multiargs build e2e tests by @ulyssessouza
