### PR TITLE
Fix aria2 session lost issue

### DIFF
--- a/net/aria2/files/aria2.init
+++ b/net/aria2/files/aria2.init
@@ -173,10 +173,20 @@ aria2_start() {
 		return 1
 	}
 
-	_create_file "$session_file" "$config_file" "$config_file_tmp" || {
-		_err "Can't create files: $session_file, $config_file, $config_file_tmp"
+	_create_file "$config_file" "$config_file_tmp" || {
+		_err "Can't create files: $config_file, $config_file_tmp"
 		return 1
 	}
+
+    # check session file existence before creating it
+	if [!-f "$session_file"]; then
+	 	_create_file "$session_file"|| {
+	 	 	_err "Can't create files: $session_file"
+	 	 	return 1
+	 	}
+	elif [!-r "$session_file" || !-w "$session_file"]; then
+		_change_file_mode 600 "$session_file"
+	fi
 
 	# create tmp file
 	cat >"$config_file_tmp" <<-EOF


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:

Aria2 session (downloading status) would loss every time aria2 service (re)starts, e.g. mannually restart aria2 service or after device reboot. 
Related issue: coolsnowwolf/lede#5829

This problem is caused by unconditionally file creation of `$session_file` by `_create_file()` in function `aria2_start()`.

In this PR, the existence of `$session_file` is checked before creating a new one. Further, if `$session_file` exists, check read&write permission of it.
