### PR TITLE
fix syntax error and funcion enhancement

### DIFF
--- a/net/aria2/files/aria2.init
+++ b/net/aria2/files/aria2.init
@@ -168,23 +168,23 @@ aria2_start() {
 	config_file_tmp="$config_dir/$NAME.conf.tmp"
 	session_file="$config_dir/$NAME.session.$section"
 
-	_make_dir "$config_dir" || {
-		_err "Can't create config dir: $config_dir"
-		return 1
-	}
+	# check directory existence before creating it
+	if [ ! -e "$config_dir" ]; then
+		_make_dir "$config_dir" || {
+			_err "Can't create config dir: $config_dir"
+			return 1
+		}
+	fi
 
 	_create_file "$config_file" "$config_file_tmp" || {
 		_err "Can't create files: $config_file, $config_file_tmp"
 		return 1
 	}
 
-    # check session file existence before creating it
-	if [!-f "$session_file"]; then
-	 	_create_file "$session_file"|| {
-	 	 	_err "Can't create files: $session_file"
-	 	 	return 1
-	 	}
-	elif [!-r "$session_file" || !-w "$session_file"]; then
+	# check session file existence before creating it
+	if [ ! -e "$session_file" ]; then
+	 	_create_file "$session_file"|| { _err "Can't create files: $session_file"; return 1; }
+	elif [ ! -r "$session_file" ] || [ ! -w "$session_file" ]; then
 		_change_file_mode 600 "$session_file"
 	fi
 


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
Fix syntax error of PR #349. Further, the existence of directory `$config_dir` is checked before creation.