### PR TITLE
stubby: fix Package stubby is missing dependencies for the following …

### DIFF
--- a/net/stubby/Makefile
+++ b/net/stubby/Makefile
@@ -32,7 +32,7 @@ define Package/stubby
   SUBMENU:=IP Addresses and Names
   TITLE+= - (daemon that uses getdns)
   USERID:=stubby=410:stubby=410
-  DEPENDS:= +libyaml +getdns +ca-certs
+  DEPENDS:= +libyaml +getdns +ca-certs +libunbound
 endef
 
 define Package/stubby/description


### PR DESCRIPTION
…libraries: libunbound.so.8

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
This pull update is for fixing error below
```
2022-01-06T19:50:05.8823281Z find /home/runner/work/HelmiWrt-OS/HelmiWrt-OS/openwrt/build_dir/target-aarch64_cortex-a72_musl/stubby-0.4.0/ipkg-aarch64_cortex-a72/stubby -name 'CVS' -o -name '.svn' -o -name '.#*' -o -name '*~'| xargs -r rm -rf
2022-01-06T19:50:05.9474790Z Package stubby is missing dependencies for the following libraries:
2022-01-06T19:50:05.9479061Z libunbound.so.8
2022-01-06T19:50:05.9491274Z make[2]: *** [/home/runner/work/HelmiWrt-OS/HelmiWrt-OS/openwrt/bin/packages/aarch64_cortex-a72/packages/stubby_0.4.0-5_aarch64_cortex-a72.ipk] Error 1
2022-01-06T19:50:05.9493294Z Makefile:60: recipe for target '/home/runner/work/HelmiWrt-OS/HelmiWrt-OS/openwrt/bin/packages/aarch64_cortex-a72/packages/stubby_0.4.0-5_aarch64_cortex-a72.ipk' failed
2022-01-06T19:50:05.9497796Z make[2]: Leaving directory '/home/runner/work/HelmiWrt-OS/HelmiWrt-OS/openwrt/customfeeds/packages/net/stubby'
2022-01-06T19:50:05.9499227Z time: package/feeds/packages/stubby/compile#1.31#0.49#1.71
2022-01-06T19:50:05.9503450Z     ERROR: package/feeds/packages/stubby failed to build.
```
