### PR TITLE
update verysync to newest

### DIFF
--- a/net/verysync/Makefile
+++ b/net/verysync/Makefile
@@ -27,7 +27,7 @@ ifeq ($(ARCH),powerpc64)
 endif
 
 PKG_NAME:=verysync
-PKG_VERSION:=2.10.4
+PKG_VERSION:=2.13.2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-linux-$(PKG_ARCH_VERYSYNC)-v$(PKG_VERSION).tar.gz


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)
x86_64
Description:
2.10.4已经被删除，因此更新到最新