### PR TITLE
rblibtorrent: bump to git HEAD

### DIFF
--- a/libs/qtbase/Makefile
+++ b/libs/qtbase/Makefile
@@ -8,17 +8,17 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=qtbase
 PKG_BASE:=5.15
-PKG_BUGFIX:=2
+PKG_BUGFIX:=3
 PKG_VERSION:=$(PKG_BASE).$(PKG_BUGFIX)
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-everywhere-src-$(PKG_VERSION).tar.xz
+PKG_SOURCE:=$(PKG_NAME)-everywhere-opensource-src-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 		http://download.qt.io/official_releases/qt/$(PKG_BASE)/$(PKG_VERSION)/submodules \
 		http://master.qt.io/archive/qt/$(PKG_BASE)/$(PKG_VERSION)/submodules \
 		http://mirrors.tuna.tsinghua.edu.cn/qt/archive/qt/$(PKG_BASE)/$(PKG_VERSION)/submodules \
 		http://qt.mirror.constant.com/archive/qt/$(PKG_BASE)/$(PKG_VERSION)/submodules
-PKG_HASH:=909fad2591ee367993a75d7e2ea50ad4db332f05e1c38dd7a5a274e156a4e0f8
+PKG_HASH:=26394ec9375d52c1592bd7b689b1619c6b8dbe9b6f91fdd5c355589787f3a0b6
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-everywhere-src-$(PKG_VERSION)
 

--- a/libs/qtbase/patches/010-gcc11.patch
+++ b/libs/qtbase/patches/010-gcc11.patch
@@ -1,27 +1,3 @@
-diff --color -uNr a/src/corelib/global/qendian.h b/src/corelib/global/qendian.h
---- a/src/corelib/global/qendian.h	2020-10-27 16:02:11.000000000 +0800
-+++ b/src/corelib/global/qendian.h	2021-07-19 06:21:23.185297425 +0800
-@@ -43,7 +43,7 @@
- 
- #include <QtCore/qfloat16.h>
- #include <QtCore/qglobal.h>
--
-+#include <limits>
- // include stdlib.h and hope that it defines __GLIBC__ for glibc-based systems
- #include <stdlib.h>
- #include <string.h>
-diff --color -uNr a/src/corelib/global/qfloat16.h b/src/corelib/global/qfloat16.h
---- a/src/corelib/global/qfloat16.h	2020-10-27 16:02:11.000000000 +0800
-+++ b/src/corelib/global/qfloat16.h	2021-07-19 06:22:10.387349829 +0800
-@@ -44,7 +44,7 @@
- #include <QtCore/qglobal.h>
- #include <QtCore/qmetatype.h>
- #include <string.h>
--
-+#include <limits>
- #if defined(QT_COMPILER_SUPPORTS_F16C) && defined(__AVX2__) && !defined(__F16C__)
- // All processors that support AVX2 do support F16C too. That doesn't mean
- // we're allowed to use the intrinsics directly, so we'll do it only for
 diff --color -uNr a/src/corelib/text/qbytearraymatcher.h b/src/corelib/text/qbytearraymatcher.h
 --- a/src/corelib/text/qbytearraymatcher.h	2020-10-27 16:02:11.000000000 +0800
 +++ b/src/corelib/text/qbytearraymatcher.h	2021-07-19 06:22:30.139372013 +0800

--- a/libs/qttools/Makefile
+++ b/libs/qttools/Makefile
@@ -8,17 +8,17 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=qttools
 PKG_BASE:=5.15
-PKG_BUGFIX:=2
+PKG_BUGFIX:=3
 PKG_VERSION:=$(PKG_BASE).$(PKG_BUGFIX)
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-everywhere-src-$(PKG_VERSION).tar.xz
+PKG_SOURCE:=$(PKG_NAME)-everywhere-opensource-src-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 		http://download.qt.io/official_releases/qt/$(PKG_BASE)/$(PKG_VERSION)/submodules \
 		http://master.qt.io/archive/qt/$(PKG_BASE)/$(PKG_VERSION)/submodules \
 		http://mirrors.tuna.tsinghua.edu.cn/qt/archive/qt/$(PKG_BASE)/$(PKG_VERSION)/submodules \
 		http://qt.mirror.constant.com/archive/qt/$(PKG_BASE)/$(PKG_VERSION)/submodules
-PKG_HASH:=c189d0ce1ff7c739db9a3ace52ac3e24cb8fd6dbf234e49f075249b38f43c1cc
+PKG_HASH:=463b2fe71a085e7ab4e39333ae360ab0ec857b966d7a08f752c427e5df55f90d
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-everywhere-src-$(PKG_VERSION)
 

--- a/libs/rblibtorrent/Makefile
+++ b/libs/rblibtorrent/Makefile
@@ -7,9 +7,9 @@ PKG_RELEASE=1
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/arvidn/libtorrent.git
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=9c5b26b8d9bdb168256566a2986c563187638e5a
+PKG_SOURCE_VERSION:=1b25eb5584db5f335167e6f8beda1ae280f28445
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_MIRROR_HASH:=15c9d37a56cf09b22b9d1eeec8a0c21eff7c9fb6b30b04c4cba9a61d5201d57a
+PKG_MIRROR_HASH:=d0cb50a9dd6cc740dfa8f7a93be2c614a40165246c0454ae6f147cda7aa3f994
 
 PKG_LICENSE:=BSD
 PKG_LICENSE_FILES:=COPYING
@@ -56,7 +56,7 @@ endef
 
 define Package/rblibtorrent/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so.* $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib
 endef
 
 $(eval $(call BuildPackage,rblibtorrent))

--- a/libs/rblibtorrent/Makefile
+++ b/libs/rblibtorrent/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rblibtorrent
 PKG_VERSION:=1.2.15
-PKG_RELEASE=1
+PKG_RELEASE=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/arvidn/libtorrent.git


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (GCC 11 arm64 works )

Description: rblibtorrent: bump to git HEAD & Fix installation file missing symlinks
                    qtbase & qttools update to 5.15.3