### PR TITLE
openssh: update to 8.9p1

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -8,18 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssh
-PKG_VERSION:=8.8p1
+PKG_VERSION:=8.9p1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \
 		https://ftp.spline.de/pub/OpenBSD/OpenSSH/portable/
-PKG_HASH:=4590890ea9bb9ace4f71ae331785a3a5823232435161960ed5fc86588f331fe9
+PKG_HASH:=fd497654b7ab1686dac672fb83dfb4ba4096e8b5ffcdaccd262380ae58bec5e7
 
 PKG_LICENSE:=BSD ISC
 PKG_LICENSE_FILES:=LICENCE
 PKG_CPE_ID:=cpe:/a:openssh:openssh
 
+PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=
 PKG_CONFIG_DEPENDS := \
 	CONFIG_OPENSSH_LIBFIDO2

--- a/net/openssh/patches/010-32bit-seccomp.patch
+++ b/net/openssh/patches/010-32bit-seccomp.patch
@@ -1,0 +1,24 @@
+From 995cf19fbef0b10dbcf1dd8d6382cec9194e08c5 Mon Sep 17 00:00:00 2001
+From: Darren Tucker <dtucker@dtucker.net>
+Date: Sat, 26 Feb 2022 14:06:14 +1100
+Subject: [PATCH] Allow ppoll_time64 in seccomp sandbox.
+
+Should fix sandbox violations on (some? at least i386 and armhf) 32bit
+Linux platforms.  Patch from chutzpahu at gentoo.org and cjwatson at
+debian.org via bz#3396.
+---
+ sandbox-seccomp-filter.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/sandbox-seccomp-filter.c
++++ b/sandbox-seccomp-filter.c
+@@ -276,6 +276,9 @@ static const struct sock_filter preauth_
+ #ifdef __NR_ppoll
+ 	SC_ALLOW(__NR_ppoll),
+ #endif
++#ifdef __NR_ppoll_time64
++	SC_ALLOW(__NR_ppoll_time64),
++#endif
+ #ifdef __NR_poll
+ 	SC_ALLOW(__NR_poll),
+ #endif

--- a/net/openssh/patches/020-improve-detection-of-fzero-call-used-regs.patch
+++ b/net/openssh/patches/020-improve-detection-of-fzero-call-used-regs.patch
@@ -1,0 +1,30 @@
+From 6c4a67ece33d9551429490898bb3c793a689e913 Mon Sep 17 00:00:00 2001
+From: Colin Watson <cjwatson@debian.org>
+Date: Thu, 24 Feb 2022 16:04:18 +0000
+Subject: [PATCH] Improve detection of -fzero-call-used-regs=all support
+
+GCC doesn't tell us whether this option is supported unless it runs into
+the situation where it would need to emit corresponding code.
+---
+ m4/openssh.m4 | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/m4/openssh.m4
++++ b/m4/openssh.m4
+@@ -14,6 +14,8 @@ AC_DEFUN([OSSH_CHECK_CFLAG_COMPILE], [{
+ 	AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+ #include <stdlib.h>
+ #include <stdio.h>
++/* Trivial function to help test for -fzero-call-used-regs */
++void f(int n) {}
+ int main(int argc, char **argv) {
+ 	(void)argv;
+ 	/* Some math to catch -ftrapv problems in the toolchain */
+@@ -21,6 +23,7 @@ int main(int argc, char **argv) {
+ 	float l = i * 2.1;
+ 	double m = l / 0.5;
+ 	long long int n = argc * 12345LL, o = 12345LL * (long long int)argc;
++	f(0);
+ 	printf("%d %d %d %f %f %lld %lld\n", i, j, k, l, m, n, o);
+ 	/*
+ 	 * Test fallthrough behaviour.  clang 10's -Wimplicit-fallthrough does


### PR DESCRIPTION
Maintainer: @tripolar
Compile tested: aarch64, Turris MOX, OpenWrt master
Run tested: aarch64, Turris MOX, OpenWrt master

Description: According to reports from other distributions, using openssh server 8.9p1 on 32bit architectures without 32bit-seccomp.patch (which is already upstream in the 8.9 maintenance branch) does not accept connections. I didn't test this if OpenWrt is affected by this bug yet.
