### PR TITLE
expat: add CMAKE_HOST_OPTIONS

### DIFF
--- a/libs/expat/Makefile
+++ b/libs/expat/Makefile
@@ -35,7 +35,7 @@ define Package/libexpat/description
  A fast, non-validating, stream-oriented XML parsing library.
 endef
 
-CMAKE_OPTIONS += \
+OPTIONS += \
 	-DDOCBOOK_TO_MAN=OFF \
 	-DEXPAT_BUILD_TOOLS=OFF \
 	-DEXPAT_BUILD_EXAMPLES=OFF \
@@ -46,6 +46,9 @@ CMAKE_OPTIONS += \
 	-DEXPAT_DTD=OFF \
 	-DEXPAT_NS=OFF \
 	-DEXPAT_DEV_URANDOM=OFF
+
+ CMAKE_OPTIONS += $(OPTIONS)
+ CMAKE_HOST_OPTIONS += $(OPTIONS)
 
 define Package/libexpat/install
 	$(INSTALL_DIR) $(1)/usr/lib


### PR DESCRIPTION
add CMAKE_HOST_OPTIONS back to fix host-build errors.