### PR TITLE
netdata: add liblz4 deps

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -31,7 +31,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/netdata
   SECTION:=admin
   CATEGORY:=Administration
-  DEPENDS:=+zlib +libuuid +libuv +libmnl +libjson-c
+  DEPENDS:=+zlib +libuuid +libuv +libmnl +libjson-c +liblz4
   TITLE:=Real-time performance monitoring tool
   URL:=https://www.netdata.cloud/
 endef


### PR DESCRIPTION
fix:
Package netdata is missing dependencies for the following libraries:
liblz4.so.1
