### PR TITLE
qBittorrent: update to 4.4.2

### DIFF
--- a/net/qBittorrent/Makefile
+++ b/net/qBittorrent/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=qbittorrent
-PKG_VERSION:=4.4.1
+PKG_VERSION:=4.4.2
 PKG_RELEASE=1
 
 PKG_SOURCE:=qBittorrent-release-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/qbittorrent/qBittorrent/tar.gz/release-$(PKG_VERSION)?
-PKG_HASH:=144a609514a7b516e65c4a4e32e49529b5e3949a713daf86332cd95867c991ba
+PKG_HASH:=f9406eb982a4b8a084341fb0bc30bd8b50babe5dcf4197204ab407b06e20e8a3
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/qBittorrent-release-$(PKG_VERSION)
 


### PR DESCRIPTION
v4.4.2 changelog:

FEATURE: Allow to limit max memory working set size (glassez)
BUGFIX: Fix UI crash when torrent is in a non-existent category (Kevin Cox)
BUGFIX: Correctly handle changing of global save paths (glassez)
BUGFIX: Disable performance alert (Chocobo1)
BUGFIX: Prevent loading resume data with inconsistent ID (glassez)
BUGFIX: Properly handle metadata download for an existing torrent (glassez)
BUGFIX: Prevent crash when open torrent destination folder (glassez)
WINDOWS: NSIS: Update Spanish, Spanish International and French translations(Juanjo Jiménez, RqndomHax)
