### PR TITLE
gnutls: Update to 3.7.4

### DIFF
--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -21,6 +21,7 @@ PKG_LICENSE:=LGPL-2.1-or-later
 PKG_CPE_ID:=cpe:/a:gnu:gnutls
 
 PKG_INSTALL:=1
+PKG_BUILD_DEPENDS:=gettext-full/host
 PKG_BUILD_PARALLEL:=1
 PKG_LIBTOOL_PATHS:=. lib
 

--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnutls
-PKG_VERSION:=3.7.2
+PKG_VERSION:=3.7.4
 PKG_RELEASE:=$(AUTORELEASE)
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.gnupg.org/ftp/gcrypt/gnutls/v3.7
-PKG_HASH:=646e6c5a9a185faa4cea796d378a1ba8e1148dbb197ca6605f95986a25af2752
+PKG_HASH:=e6adbebcfbc95867de01060d93c789938cf89cc1d1f6ef9ef661890f6217451f
 PKG_FIXUP:=autoreconf gettext-version
 PKG_MAINTAINER:=Nikos Mavrogiannopoulos <nmav@gnutls.org>
 PKG_LICENSE:=LGPL-2.1-or-later
@@ -133,7 +133,8 @@ CONFIGURE_ARGS+= \
 	--with-included-unistring \
 	--with-librt-prefix="$(LIBRT_ROOT_DIR)/" \
 	--with-pic \
-	--with-system-priority-file=""
+	--with-system-priority-file="" \
+	--without-libzstd
 
 ifneq ($(CONFIG_GNUTLS_EXT_LIBTASN1),y)
 CONFIGURE_ARGS += --with-included-libtasn1

--- a/libs/gnutls/patches/010-m4.patch
+++ b/libs/gnutls/patches/010-m4.patch
@@ -62,7 +62,7 @@
      [AC_COMPILE_IFELSE(
 --- a/src/gl/m4/gnulib-comp.m4
 +++ b/src/gl/m4/gnulib-comp.m4
-@@ -1164,7 +1164,7 @@ changequote([, ])dnl
+@@ -1188,7 +1188,7 @@ changequote([, ])dnl
    gl_UNISTD_MODULE_INDICATOR([sleep])
    AC_CHECK_DECLS_ONCE([alarm])
    AC_REQUIRE([gt_TYPE_WCHAR_T])

--- a/libs/gnutls/patches/020-dont-install-m4-files.patch
+++ b/libs/gnutls/patches/020-dont-install-m4-files.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Eneas U de Queiroz <cote2004-github@yahoo.com>
+Date: Mon, 25 Oct 2021 08:49:21 -0300
+Subject: Do not install m4 files
+
+Do not use --install when calling aclocal.  That flag instructs aclocal to
+copy third-party files to the first -I directory.  The intention here is to
+copy files to the package build dir (m4).  However, our toolchain prepends
+the build-system's m4 dir to the list, causing the --install flag to
+install an older version to the buildsystem m4 dir, causing failures in
+other packages.
+
+Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>
+
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -57,7 +57,7 @@ if ENABLE_DOC
+ SUBDIRS += doc
+ endif
+ 
+-ACLOCAL_AMFLAGS = -I m4 -I src/libopts/m4 -I src/gl/m4 -I lib/unistring/m4 --install
++ACLOCAL_AMFLAGS = -I m4 -I src/libopts/m4 -I src/gl/m4 -I lib/unistring/m4
+ 
+ EXTRA_DIST = cfg.mk maint.mk CONTRIBUTING.md README.md LICENSE AUTHORS NEWS \
+ 	ChangeLog THANKS INSTALL.md RELEASES.md

--- a/libs/gnutls/patches/020-dont-install-m4-files.patch
+++ b/libs/gnutls/patches/020-dont-install-m4-files.patch
@@ -18,8 +18,8 @@ Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>
  SUBDIRS += doc
  endif
  
--ACLOCAL_AMFLAGS = -I m4 -I src/libopts/m4 -I src/gl/m4 -I lib/unistring/m4 --install
-+ACLOCAL_AMFLAGS = -I m4 -I src/libopts/m4 -I src/gl/m4 -I lib/unistring/m4
+-ACLOCAL_AMFLAGS = -I m4 -I src/gl/m4 -I lib/unistring/m4 --install
++ACLOCAL_AMFLAGS = -I m4 -I src/gl/m4 -I lib/unistring/m4
  
  EXTRA_DIST = cfg.mk maint.mk CONTRIBUTING.md README.md LICENSE AUTHORS NEWS \
- 	ChangeLog THANKS INSTALL.md RELEASES.md
+ 	ChangeLog THANKS INSTALL.md RELEASES.md .mailmap


### PR DESCRIPTION
Bump to latest upstream release. Rebased existing patches.

Signed-off-by: John Audia [graysky@archlinux.us](mailto:graysky@archlinux.us)
