### PR TITLE
gnutls: disable zlib

### DIFF
--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -135,7 +135,8 @@ CONFIGURE_ARGS+= \
 	--with-librt-prefix="$(LIBRT_ROOT_DIR)/" \
 	--with-pic \
 	--with-system-priority-file="" \
-	--without-libzstd
+	--without-libzstd \
+        --without-zlib
 
 ifneq ($(CONFIG_GNUTLS_EXT_LIBTASN1),y)
 CONFIGURE_ARGS += --with-included-libtasn1


### PR DESCRIPTION
Fixes:
Package libgnutls is missing dependencies for the following libraries:
libz.so.1
Disable zlib support to avoid that.
Signed-off-by: John Audia <graysky@archlinux.us>
[disable zlib and zstd]
Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>
