### PR TITLE
nlbwmon: netlink_buffer_size 16777216

### DIFF
--- a/net/nlbwmon/files/nlbwmon.config
+++ b/net/nlbwmon/files/nlbwmon.config
@@ -2,7 +2,7 @@ config nlbwmon
 	# The buffer size for receiving netlink conntrack results, in bytes.
 	# If the chosen size is too small, accounting information might get
 	# lost, leading to skewed traffic counting results
-	option netlink_buffer_size 1048576
+	option netlink_buffer_size 16777216
 
 	# Interval at which the temporary in-memory database is committed to
 	# the persistent database directory


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
