### PR TITLE
golang : bump to 1.18

### DIFF
--- a/lang/golang/golang-build.sh
+++ b/lang/golang/golang-build.sh
@@ -56,7 +56,7 @@ configure() {
 	if [ "$GO_INSTALL_ALL" != 1 ]; then
 		code="$(printf '%s\n' "$files" | grep '\.\(c\|cc\|cpp\|go\|h\|hh\|hpp\|proto\|s\)$')"
 		testdata="$(printf '%s\n' "$files" | grep '/testdata/')"
-		gomod="$(printf '%s\n' "$files" | grep '/go\.\(mod\|sum\)$')"
+		gomod="$(printf '%s\n' "$files" | grep '/go\.\(mod\|sum\|work\)$')"
 
 		for pattern in $GO_INSTALL_EXTRA; do
 			extra="$(printf '%s\n' "$extra"; printf '%s\n' "$files" | grep -e "$pattern")"

--- a/lang/golang/golang-package.mk
+++ b/lang/golang/golang-package.mk
@@ -32,7 +32,7 @@ include $(GO_INCLUDE_DIR)/golang-values.mk
 #
 #   * Files in any 'testdata' directory
 #
-#   * go.mod and go.sum, in any directory
+#   * go.mod, go.sum and go.work, in any directory
 #
 #   e.g. GO_PKG_INSTALL_EXTRA:=example.toml marshal_test.toml
 #
@@ -198,9 +198,11 @@ GO_PKG_TARGET_VARS= \
 	GOOS="$(GO_OS)" \
 	GOARCH="$(GO_ARCH)" \
 	GO386="$(GO_386)" \
+	GOAMD64="$(GO_AMD64)" \
 	GOARM="$(GO_ARM)" \
 	GOMIPS="$(GO_MIPS)" \
 	GOMIPS64="$(GO_MIPS64)" \
+	GOPPC64="$(GO_PPC64)" \
 	CGO_ENABLED=1 \
 	CC="$(TARGET_CC)" \
 	CXX="$(TARGET_CXX)" \

--- a/lang/golang/golang-values.mk
+++ b/lang/golang/golang-values.mk
@@ -29,7 +29,8 @@ unexport \
   GOOS \
   GOPATH \
   GOROOT \
-  GOTMPDIR
+  GOTMPDIR \
+  GOWORK
 # Unmodified:
 #   GOINSECURE
 #   GOPRIVATE
@@ -58,8 +59,10 @@ unexport \
 unexport \
   GOARM \
   GO386 \
+  GOAMD64 \
   GOMIPS \
   GOMIPS64 \
+  GOPPC64 \
   GOWASM
 
 # Special-purpose environment variables:
@@ -86,13 +89,12 @@ unexport \
 #   CC_FOR_${GOOS}_${GOARCH}
 #   CXX_FOR_${GOOS}_${GOARCH}
 
-# From https://golang.org/doc/install/source#environment
+# From https://go.dev/doc/install/source#environment
 unexport \
   GOHOSTOS \
-  GOHOSTARCH \
-  GOPPC64
+  GOHOSTARCH
 
-# From https://golang.org/src/make.bash
+# From https://go.dev/src/make.bash
 unexport \
   GO_GCFLAGS \
   GO_LDFLAGS \
@@ -101,16 +103,16 @@ unexport \
   GOBUILDTIMELOGFILE \
   GOROOT_BOOTSTRAP
 
-# From https://golang.org/doc/go1.9#parallel-compile
+# From https://go.dev/doc/go1.9#parallel-compile
 unexport \
   GO19CONCURRENTCOMPILATION
 
-# From https://golang.org/src/cmd/dist/build.go
+# From https://go.dev/src/cmd/dist/build.go
 unexport \
   BOOT_GO_GCFLAGS \
   BOOT_GO_LDFLAGS
 
-# From https://golang.org/src/cmd/dist/buildtool.go
+# From https://go.dev/src/cmd/dist/buildtool.go
 unexport \
   GOBOOTSTRAP_TOOLEXEC
 
@@ -152,6 +154,9 @@ ifeq ($(GO_ARCH),386)
   # -fno-plt: causes "unexpected GOT reloc for non-dynamic symbol" errors
   GO_CFLAGS_TO_REMOVE:=-fno-plt
 
+else ifeq ($(GO_ARCH),amd64)
+  GO_AMD64:=v1
+
 else ifeq ($(GO_ARCH),arm)
   GO_TARGET_FPU:=$(word 2,$(subst +,$(space),$(call qstrip,$(CONFIG_CPU_TYPE))))
 
@@ -183,6 +188,9 @@ else ifneq ($(filter $(GO_ARCH),mips64 mips64le),)
     GO_MIPS64:=softfloat
   endif
 
+else ifeq ($(GO_ARCH),ppc64)
+  GO_PPC64:=power8
+
 endif
 
 
@@ -193,7 +201,7 @@ GO_ARCH_DEPENDS:=@(aarch64||arm||i386||i686||mips||mips64||mips64el||mipsel||pow
 
 # ASLR/PIE
 
-# From https://golang.org/src/cmd/internal/sys/supported.go
+# From https://go.dev/src/cmd/internal/sys/supported.go
 GO_PIE_SUPPORTED_OS_ARCH:= \
   android_386  android_amd64  android_arm  android_arm64 \
   linux_386    linux_amd64    linux_arm    linux_arm64 \
@@ -209,7 +217,7 @@ GO_PIE_SUPPORTED_OS_ARCH:= \
   \
   linux_ppc64le linux_riscv64 linux_s390x
 
-# From https://golang.org/src/cmd/go/internal/work/init.go
+# From https://go.dev/src/cmd/go/internal/work/init.go
 go_pie_install_suffix=$(if $(filter $(1),aix_ppc64 windows_386 windows_amd64 windows_arm),,shared)
 
 ifneq ($(filter $(GO_HOST_OS_ARCH),$(GO_PIE_SUPPORTED_OS_ARCH)),)

--- a/lang/golang/golang/Makefile
+++ b/lang/golang/golang/Makefile
@@ -7,8 +7,8 @@
 
 include $(TOPDIR)/rules.mk
 
-GO_VERSION_MAJOR_MINOR:=1.17
-GO_VERSION_PATCH:=8
+GO_VERSION_MAJOR_MINOR:=1.18
+GO_VERSION_PATCH:=
 
 PKG_NAME:=golang
 PKG_VERSION:=$(GO_VERSION_MAJOR_MINOR)$(if $(GO_VERSION_PATCH),.$(GO_VERSION_PATCH))
@@ -20,7 +20,7 @@ GO_SOURCE_URLS:=https://dl.google.com/go/ \
 
 PKG_SOURCE:=go$(PKG_VERSION).src.tar.gz
 PKG_SOURCE_URL:=$(GO_SOURCE_URLS)
-PKG_HASH:=2effcd898140da79a061f3784ca4f8d8b13d811fb2abe9dad2404442dabbdf7a
+PKG_HASH:=38f423db4cc834883f2b52344282fa7a39fbb93650dc62a11fdf0be6409bdad6
 
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
@@ -262,10 +262,11 @@ $(eval $(call GoCompiler/AddProfile,Package,$(PKG_BUILD_DIR),$(PKG_GO_PREFIX),$(
 
 PKG_GO_ZBOOTSTRAP_MODS:= \
 	s/defaultGO386 = `[^`]*`/defaultGO386 = `$(or $(GO_386),sse2)`/; \
+	s/defaultGOAMD64 = `[^`]*`/defaultGOAMD64 = `$(or $(GO_AMD64),v1)`/; \
 	s/defaultGOARM = `[^`]*`/defaultGOARM = `$(or $(GO_ARM),5)`/; \
 	s/defaultGOMIPS = `[^`]*`/defaultGOMIPS = `$(or $(GO_MIPS),hardfloat)`/; \
 	s/defaultGOMIPS64 = `[^`]*`/defaultGOMIPS64 = `$(or $(GO_MIPS64),hardfloat)`/; \
-	s/defaultGOPPC64 = `[^`]*`/defaultGOPPC64 = `power8`/;
+	s/defaultGOPPC64 = `[^`]*`/defaultGOPPC64 = `$(or $(GO_PPC64),power8)`/;
 
 PKG_GO_ZBOOTSTRAP_PATH:=$(PKG_BUILD_DIR)/src/internal/buildcfg/zbootstrap.go
 

--- a/lang/golang/golang/patches/001-cmd-link-use-gold-on-ARM-ARM64-only-if-gold-is-available.patch
+++ b/lang/golang/golang/patches/001-cmd-link-use-gold-on-ARM-ARM64-only-if-gold-is-available.patch
@@ -1,8 +1,19 @@
-This is https://github.com/golang/go/pull/49748 backported for Go 1.17.
+From 5ccf9f47bf4f5ba53e0ab7338a7fd4626714cfb2 Mon Sep 17 00:00:00 2001
+From: Jeffery To <jeffery.to@gmail.com>
+Date: Tue, 23 Nov 2021 15:05:37 +0800
+Subject: [PATCH] cmd/link: use gold on ARM/ARM64 only if gold is available
+
+COPY relocation handling on ARM/ARM64 has been fixed in recent versions
+of the GNU linker. This switches to gold only if gold is available.
+
+Fixes #22040.
+---
+ src/cmd/link/internal/ld/lib.go | 19 +++++++------------
+ 1 file changed, 7 insertions(+), 12 deletions(-)
 
 --- a/src/cmd/link/internal/ld/lib.go
 +++ b/src/cmd/link/internal/ld/lib.go
-@@ -1391,23 +1391,18 @@ func (ctxt *Link) hostlink() {
+@@ -1393,25 +1393,20 @@ func (ctxt *Link) hostlink() {
  		}
  
  		if ctxt.Arch.InFamily(sys.ARM, sys.ARM64) && buildcfg.GOOS == "linux" {
@@ -24,7 +35,9 @@ This is https://github.com/golang/go/pull/49748 backported for Go 1.17.
 -			// back to ld.bfd. So we parse the version information
 -			// and provide a useful error if gold is missing.
 +			// In both cases, switch to gold if gold is available.
- 			cmd := exec.Command(*flagExtld, "-fuse-ld=gold", "-Wl,--version")
+ 			name, args := flagExtld[0], flagExtld[1:]
+ 			args = append(args, "-fuse-ld=gold", "-Wl,--version")
+ 			cmd := exec.Command(name, args...)
  			if out, err := cmd.CombinedOutput(); err == nil {
 -				if !bytes.Contains(out, []byte("GNU gold")) {
 -					log.Fatalf("ARM external linker must be gold (issue #15696), but is not: %s", out)


### PR DESCRIPTION
Compile tested: x86_64 OpenWrt R22.4.1
Run tested: x86_64 OpenWrt R22.4.1

Description:
Update golang to 1.18