### PR TITLE
miniupnpd: change download repo url

### DIFF
--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -11,7 +11,10 @@ PKG_NAME:=miniupnpd
 PKG_VERSION:=2.0.20170421
 PKG_RELEASE:=3
 
-PKG_SOURCE_URL:=http://miniupnp.free.fr/files
+# Content-Encoding conflict, can refer to this [issue](https://github.com/miniupnp/miniupnp/issues/605)
+# so switch mirror repo to http://miniupnp.tuxfamily.org
+# PKG_SOURCE_URL:=http://miniupnp.free.fr/files
+PKG_SOURCE_URL:=http://miniupnp.tuxfamily.org/files
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_HASH:=9677aeccadf73b4bf8bb9d832c32b5da8266b4d58eed888f3fd43d7656405643
 


### PR DESCRIPTION
Maintainer: me 
Compile tested: lede tag *[20211107](https://github.com/geniusjoe/lede/releases/tag/20211107)*
Run tested: self menual test.

Description:

在使用 lede 拉取 feed 后，执行 `make download` 下载 `miniupnpd` 包时，会出现 curl 下载进度到 100% 后卡住的现象。
```
curl -f --connect-timeout 20 --retry 5 --location --insecure http://miniupnp.free.fr/files/miniupnpd-2.0.20170421.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1010k    0 1010k    0     0    207      0 --:--:--  1:23:13 --:--:-- 
```

排查原因后发现是 `miniupnpd` 镜像在下载时，实际上下载的是 `.tar` 后缀，而非 `.tar.gz` 后缀的包。目前这个问题已经被 `miniupnpd` 修复，但是在使用浏览器在 [镜像仓库网站](http://miniupnp.free.fr/files) 手动下载 [该文件](http://miniupnp.free.fr/files/download.php?file=miniupnpd-2.0.20170421.tar.gz) 时，还是会出现下载的为 tar 而非 gz 的问题。

![image](https://user-images.githubusercontent.com/37236056/166230303-4c123f8e-54f1-42cc-95fa-2680c835d782.png)


我也提交了个 [issue](https://github.com/miniupnp/miniupnp/issues/605) 给 `miniupnpd`，他们的解释是使用该 [镜像网站](http://miniupnp.free.fr/files) 时， http 包头中会携带 `Content-Encoding: x-gzip`，导致浏览器或 curl 程序自行解压产生兼容性问题。他们提出的解决办法是切换到 `miniupnp.tuxfamily.org` 镜像仓库进行下载。

> I think there is an issue with the way the webserver advertise .tar.gz files. Please download from https://miniupnp.tuxfamily.org/

经测试，新镜像仓库的包 `sha256` 和原仓库保持一致
```
curl -f --connect-timeout 20 --retry 5 --location --insecure http://miniupnp.tuxfamily.org/files/miniupnpd-2.0.20170421.tar.gz --output /tmp/testMirror.tar.gz
sha256sum /tmp/testMirror.tar.gz 
```

![image](https://user-images.githubusercontent.com/37236056/166231257-a6ce6f54-6f82-443e-8a55-5040c3d9f314.png)
