### PR TITLE
dockerd: update to v20.10.15

### DIFF
--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dockerd
-PKG_VERSION:=20.10.14
+PKG_VERSION:=20.10.15
 PKG_RELEASE:=$(AUTORELEASE)
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -10,8 +10,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/moby/moby
 PKG_GIT_REF:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=dbe1ae342351108b7b30232c4bce0559c81ad9fb6c978d7c8425d6aa53e476c1
-PKG_GIT_SHORT_COMMIT:=87a90dc # SHA1 used within the docker executables
+PKG_HASH:=cfb1029b48fd7ab2d03bddb55909a196e0f516b3e5495a033dfbfe00fe9fadad
+PKG_GIT_SHORT_COMMIT:=4433bf6 # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 


### PR DESCRIPTION
This release of Docker Engine comes with updated versions of the `compose`,
`buildx`, `containerd`, and `runc `components, as well as some minor bugfixes.

### Daemon
Use a RWMutex for stateCounter to prevent potential locking congestion https://github.com/moby/moby/pull/43426.
Prevent an issue where the daemon was unable to find an available IP-range in
some conditions https://github.com/moby/moby/pull/43360
### Packaging
Update Docker Compose to [v2.5.0](https://github.com/docker/compose/releases/tag/v2.5.0).
Update Docker Buildx to [v0.8.2](https://github.com/docker/buildx/releases/tag/v0.8.2).
Update Go runtime to [1.17.9](https://go.dev/doc/devel/release#go1.17.minor).
Update containerd (containerd.io package) to [v1.6.4](https://github.com/containerd/containerd/releases/tag/v1.6.3).
Update runc version to [v1.1.1](https://github.com/opencontainers/runc/releases/tag/v1.1.1).
Add packages for CentOS 9 stream and Fedora 36.
