### PR TITLE
qBittorrent: update to 4.4.3.1

### DIFF
--- a/net/qBittorrent/Makefile
+++ b/net/qBittorrent/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=qbittorrent
-PKG_VERSION:=4.4.2
+PKG_VERSION:=4.4.3.1
 PKG_RELEASE=1
 
 PKG_SOURCE:=qBittorrent-release-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/qbittorrent/qBittorrent/tar.gz/release-$(PKG_VERSION)?
-PKG_HASH:=f9406eb982a4b8a084341fb0bc30bd8b50babe5dcf4197204ab407b06e20e8a3
+PKG_HASH:=ff81fa5864c3106e24479cf0a42be41657b57875841bdfa5ec3a1921923e5da4
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/qBittorrent-release-$(PKG_VERSION)
 


### PR DESCRIPTION
Tue May 24 2022 - sledgehammer999 <sledgehammer999@qbittorrent.org> - v4.4.3.1
    - BUGFIX: Fix broken translations (sledgehammer999)

Sun May 22 2022 - sledgehammer999 <sledgehammer999@qbittorrent.org> - v4.4.3
    - BUGFIX: Correctly handle changing of temp save path (glassez)
    - BUGFIX: Fix storage in SQLite (glassez)
    - BUGFIX: Correctly apply content layout when "Skip hash check" is enabled (glassez)
    - BUGFIX: Don't corrupt IDs of v2 torrents (glassez)
    - BUGFIX: Reduce the number of hashing threads by default (improves hashing speed on HDDs) (summer)
    - BUGFIX: Prevent the "update dialog" from blocking input on other windows (summer)
    - BUGFIX: Add trackers in exported .torrent files (glassez)
    - BUGFIX: Fix wrong GUI behavior in "Optional IP address to bind to" setting (Chocobo1)
    - WEBUI: Fix WebUI crash due to missing tags from config (An0n)
    - WEBUI: Show correct location path (Chocobo1)
    - MACOS: Fix main window freezing after opening a files dialog (glassez)
