### PR TITLE
fish: Fix documentation compilation

### DIFF
--- a/utils/fish/patches/010-doc-fix-version-detection.patch
+++ b/utils/fish/patches/010-doc-fix-version-detection.patch
@@ -1,0 +1,25 @@
+--- a/doc_src/conf.py
++++ b/doc_src/conf.py
+@@ -9,7 +9,6 @@
+ import glob
+ import os.path
+ import pygments
+-import subprocess
+ from sphinx.errors import SphinxError, SphinxWarning
+ from docutils import nodes, utils
+ 
+@@ -77,13 +76,8 @@ copyright = "2020, fish-shell developers
+ author = "fish-shell developers"
+ issue_url = "https://github.com/fish-shell/fish-shell/issues"
+ 
+-# Parsing FISH-BUILD-VERSION-FILE is possible but hard to ensure that it is in the right place
+-# fish_indent is guaranteed to be on PATH for the Pygments highlighter anyway
+-ret = subprocess.check_output(
+-    ("fish_indent", "--version"), stderr=subprocess.STDOUT
+-).decode("utf-8")
+ # The full version, including alpha/beta/rc tags
+-release = ret.strip().split(" ")[-1]
++release = "3.2.2"
+ # The short X.Y version
+ version = release.rsplit(".", 1)[0]
+ 


### PR DESCRIPTION
* `fish_indent` command is not available in cross-compilation context

Signed-off-by: MkfsSion <mkfssion@mkfssion.com>