### PR TITLE
docker-compose: Update to version 2.7.0

### DIFF
--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=compose
-PKG_VERSION:=2.6.1
+PKG_VERSION:=2.7.0
 PKG_RELEASE:=$(AUTORELEASE)
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/docker/compose/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=7d4ad5354e382809368016210b33c4f6c3bca68da15e36edc671da00fb234666
+PKG_HASH:=bc3e4c0aadfd3c87e8ebcd89d5236977ba8234a8211fea63351bb752d28883ae
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 


### PR DESCRIPTION
What's Changed:

 - Enhancements:

   - add support of environment secret during build step by @glours

 - Fixes:

   - networks: prevent issues due to duplicate names by @milas
   - Use appropriate dependency condition for one-shot containers when
   running compose up --wait by @laurazard
   - Fix environment variable expansion by @ulyssessouza in
   compose-spec/compose-go#276
   - Validate depended-on services exist in consistency check by
   @laurazard in compose-spec/compose-go#281
   - Fix hash usage in environment values by @ulyssessouza in
   compose-spec/compose-go#283
   - build: respect dependency order for classic builder by @milas
   - fix: panic caused by empty string argument by @nicksieger
   - (re)start should not impact one-off containers by @ndeloof
   - Fix issue with close networks name on up and down command by
   @glours
   - keep the container reference when volumes_from target a container
   and not a service by @glours
   - build.go: initialize CustomLabels map if nil by @paroque28

Signed-off-by: Javier Marcet <javier@marcet.info>

