### PR TITLE
fix softether openvpn static route push issue

### DIFF
--- a/net/softethervpn5/patches/150_remove-restriction.patch
+++ b/net/softethervpn5/patches/150_remove-restriction.patch
@@ -1,6 +1,6 @@
---- a/src/Cedar/Server.c	2022-08-04 06:26:10.816413980 +0000
-+++ b/src/Cedar/Server.c	2022-08-04 06:34:32.361586024 +0000
-@@ -10628,6 +10628,7 @@
+--- a/src/Cedar/Server.c	2020-04-30 16:48:22.000000000 +0800
++++ b/src/Cedar/Server.c	2022-08-12 15:08:36.000000000 +0800
+@@ -10624,6 +10624,7 @@
  // 
  bool SiIsEnterpriseFunctionsRestrictedOnOpenSource(CEDAR *c)
  {

--- a/net/softethervpn5/patches/151-fix-openvpn-static-route-push.patch
+++ b/net/softethervpn5/patches/151-fix-openvpn-static-route-push.patch
@@ -1,0 +1,13 @@
+--- a/src/Cedar/Proto_OpenVPN.c	2020-04-30 16:48:22.000000000 +0800
++++ b/src/Cedar/Proto_OpenVPN.c	2022-08-12 15:12:00.000000000 +0800
+@@ -2436,8 +2436,8 @@
+ 											if (r->Exists)
+ 											{
+ 												Format(l3_options, sizeof(l3_options),
+-													",route %r %r vpn_gateway",
+-													&r->Network, &r->SubnetMask);
++													",route %r %r %r",
++													&r->Network, &r->SubnetMask, &r->Gateway);
+ 
+ 												StrCat(option_str, sizeof(option_str), l3_options);
+ 											}


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: x86_64
Run tested: tested on N5105 x64
Description:
Cherry picked a patch for fixing softether openvpn protocol can't correctly push static routes.
Also fixed patch file line ending issue.