### PR TITLE
qBittorrent: update to 4.4.4

### DIFF
--- a/net/qBittorrent/Makefile
+++ b/net/qBittorrent/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=qbittorrent
-PKG_VERSION:=4.4.3.1
+PKG_VERSION:=4.4.4
 PKG_RELEASE=1
 
 PKG_SOURCE:=qBittorrent-release-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/qbittorrent/qBittorrent/tar.gz/release-$(PKG_VERSION)?
-PKG_HASH:=ff81fa5864c3106e24479cf0a42be41657b57875841bdfa5ec3a1921923e5da4
+PKG_HASH:=eb0c18cce05f90f0f61d73fecba25c1f9c9e2091633b822b6a3fab8fa85015c5
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/qBittorrent-release-$(PKG_VERSION)
 


### PR DESCRIPTION
Mon Aug 22 2022 - sledgehammer999 <sledgehammer999@qbittorrent.org> - v4.4.4
    - BUGFIX: Correctly handle data decompression with Qt 6.3 (brvphoenix)
    - BUGFIX: Fix wrong file names displayed in tooltip (Chocobo1)
    - BUGFIX: Fix incorrect "max outgoing port" setting (glassez)
    - BUGFIX: Make working set limit available only on libtorrent 2.0.x builds (summer)
    - BUGFIX: Try to recover missing tags (summer)
    - RSS: Clear RSS parsing error after use (glassez)
    - WEBAPI: Set HTTP method restriction on WebAPI actions (Chocobo1)
    - WINDOWS: Work around application stuttering on Windows (Chocobo1)
    - WINDOWS: NSIS: Update Portuguese, Italian, Korean, Latvian translations(Blackspirits, bovirus, Minseo Lee, Coool)
    - LINUX: Improve D-Bus notifications handling (glassez)
    - MACOS: Open destination folders on macOS in separate thread (Nick Korotysh)
