### PR TITLE
add webdav

### DIFF
--- a/net/webdav-hacdias/Makefile
+++ b/net/webdav-hacdias/Makefile
@@ -1,0 +1,51 @@
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=webdav-hacdias
+PKG_VERSION:=4.2.0
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/hacdias/webdav.git
+PKG_SOURCE_DATE:=2022-5-30
+PKG_SOURCE_VERSION:=436a3b0
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
+PKG_MIRROR_HASH:=5587cf5bddfb5f8b57f8ad23e521ddfd6c623ebb2f7381555c3f20d7f147d7e8
+
+PKG_LICENSE:=GPLv3
+PKG_MAINTAINER:=ElonH <elonhhuang@gmail.com>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0 # https://github.com/openwrt/packages/issues/8498
+GO_PKG:=github.com/hacdias/webdav
+GO_PKG_LDFLAGS:=-s -w
+
+include $(INCLUDE_DIR)/package.mk
+include $(TOPDIR)/feeds/packages/lang/golang/golang-package.mk
+
+define Package/$(PKG_NAME)
+	SECTION:=net
+        CATEGORY:=Network
+        SUBMENU:=File Transfer
+	TITLE:=A powerful WebDav server written in Golang.
+	URL:=https://github.com/hacdias/webdav
+	DEPENDS:=$(GO_ARCH_DEPENDS) 
+endef
+
+define Package/$(PKG_NAME)/description
+webdav command line interface is really easy to use so you can easily create a WebDAV server for your own user.
+By default, it runs on a random free port and supports JSON, YAML and TOML configuration.
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/usr/bin/ $(1)/etc/config/ $(1)/etc/init.d/ $(1)/etc/webdav/
+	$(INSTALL_BIN) $(GO_PKG_BUILD_BIN_DIR)/webdav $(1)/usr/bin/
+	$(INSTALL_CONF) $(CURDIR)/files/webdav.yaml $(1)/etc/webdav/webdav.yaml
+	$(INSTALL_CONF) $(CURDIR)/files/webdav.config $(1)/etc/config/webdav
+	$(INSTALL_BIN) $(CURDIR)/files/webdav.init $(1)/etc/init.d/webdav
+endef
+
+$(eval $(call GoBinPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/net/webdav-hacdias/files/webdav.config
+++ b/net/webdav-hacdias/files/webdav.config
@@ -1,0 +1,3 @@
+
+config webdav 'config'
+	option enabled '0'

--- a/net/webdav-hacdias/files/webdav.init
+++ b/net/webdav-hacdias/files/webdav.init
@@ -1,0 +1,22 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2021 ImmortalWrt
+
+START=90
+STOP=10
+
+WEBDAV="/usr/bin/webdav"
+
+WEBDAVCONFIG="/etc/webdav/webdav.yaml"
+
+start() {
+	local enabled="$(uci get webdav.config.enabled)"
+	stop
+	[ "${enabled}" == "1" ] || exit 0
+	export HOME="/root/"
+	"${WEBDAV}" -c "${WEBDAVCONFIG}" >/dev/null 2>&1 &
+}
+
+stop() {
+	killall -9 pgrep "${WEBDAV}" >/dev/null 2>&1
+}
+

--- a/net/webdav-hacdias/files/webdav.yaml
+++ b/net/webdav-hacdias/files/webdav.yaml
@@ -1,0 +1,37 @@
+# Server related settings
+address: 0.0.0.0
+port: 10880
+auth: true
+tls: false
+cert: cert.pem
+key: key.pem
+prefix: /
+
+# Default user settings (will be merged)
+scope: .
+modify: true
+rules: []
+
+# CORS configuration
+cors:
+  enabled: true
+  credentials: true
+  allowed_headers:
+    - Depth
+  allowed_hosts:
+    - http://localhost:8999
+  allowed_methods:
+    - GET
+  exposed_headers:
+    - Content-Length
+    - Content-Range
+
+users:
+  - username: video
+    password: 123
+    scope: /mnt/sdb1
+    modify:   true
+    rules:
+      - regex: false
+        allow: false
+        path: /some/file


### PR DESCRIPTION
来源：https://github.com/hacdias/webdav
相比原版只修改了一处造成固件备份配置文件时会错误的备份整个系统，其余未修改。

简单的webdav共享，配合luci那边的提交，简单的配置文件。
长达1个月的测试，至少在视频文件分享方面没啥问题，配置文件说明见来源页，支持多用户，支持自定义端口。
不要使用网页直接打开，这样只会显示网页源代码。
默认不走https，win10可能需要启用不安全项并通过添加一个网络位置使用，电视盒子啥的直接用没啥问题。
可能由于文件系统或缓存原因传输文件时不会实时更新进度条。
测试主要使用电视kodi播放超大体积蓝光原盘（比如高达100+GB的单文件视频）
kodi使用webdav协议时会默认启用缓存。
可能不具备太多的安全性，开放外网请走加密。