### PR TITLE
dockerd: Update to v20.10.18

### DIFF
--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dockerd
-PKG_VERSION:=20.10.17
+PKG_VERSION:=20.10.18
 PKG_RELEASE:=$(AUTORELEASE)
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -10,8 +10,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/moby/moby
 PKG_GIT_REF:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=061cf8579aa3c813c353c80fa480744e2f6cca2e6392f546bd0942a6a10c7a14
-PKG_GIT_SHORT_COMMIT:=a89b842 # SHA1 used within the docker executables
+PKG_HASH:=9907aaaf39fb1c2c3fd427192e4a63d7adf8ddc9fb0e29c692a6ca10de9c34f6
+PKG_GIT_SHORT_COMMIT:=e42327a # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 


### PR DESCRIPTION
This release of Docker Engine comes with a fix for a low-severity security issue,
some minor bug fixes, and updated versions of Docker Compose, Docker Buildx,
containerd, and runc.

Client
Add Bash completion for Docker Compose https://github.com/docker/cli/pull/3752.
Builder
Fix an issue where file-capabilities were not preserved during build https://github.com/moby/moby/pull/43876.
Fix an issue that could result in a panic caused by a concurrent map read and map write https://github.com/moby/moby/pull/44067
Daemon
Fix a security vulnerability relating to supplementary group permissions, which
could allow a container process to bypass primary group restrictions within the
container [CVE-2022-36109](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-36109), [GHSA-rc4r-wh2q-q6c4](https://github.com/moby/moby/security/advisories/GHSA-rc4r-wh2q-q6c4).
seccomp: add support for Landlock syscalls in default policy https://github.com/moby/moby/pull/43991.
seccomp: update default policy to support new syscalls introduced in kernel 5.12 - 5.16 https://github.com/moby/moby/pull/43991.
Fix an issue where cache lookup for image manifests would fail, resulting
in a redundant round-trip to the image registry https://github.com/moby/moby/pull/44109.
Fix an issue where exec processes and healthchecks were not terminated
when they timed out https://github.com/moby/moby/pull/44018.
Packaging
Update Docker Buildx to [v0.9.1](https://github.com/docker/buildx/releases/tag/v0.9.1).
Update Docker Compose to [v2.10.2](https://github.com/docker/compose/releases/tag/v2.10.2).
Update containerd (containerd.io package) to [v1.6.8](https://github.com/containerd/containerd/releases/tag/v1.6.8).
Update runc to [v1.1.4](https://github.com/opencontainers/runc/releases/tag/v1.1.4).
Update Go runtime to [1.18.6](https://go.dev/doc/devel/release#go1.18.minor),
which contains fixes for [CVE-2022-27664](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-27664)
and [CVE-2022-32190](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-32190).
