### PR TITLE
smartdns: bump to 1.2022.38

### DIFF
--- a/net/smartdns/Makefile
+++ b/net/smartdns/Makefile
@@ -1,18 +1,18 @@
 #
-# Copyright (c) 2018-2020 Nick Peng (pymumu@gmail.com)
+# Copyright (c) 2018-2022 Nick Peng (pymumu@gmail.com)
 # This is free software, licensed under the GNU General Public License v3.
 #
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=smartdns
-PKG_VERSION:=1.2022.37
+PKG_VERSION:=1.2022.38
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://www.github.com/pymumu/smartdns.git
-PKG_SOURCE_VERSION:=5a2559f0648198c290bb8839b9f6a0adab8ebcdc
-PKG_MIRROR_HASH:=29f0aa9eea2f98765be5377266c4b0c51a089ec132d51cd07a6adaec157f3b4b
+PKG_SOURCE_VERSION:=1991a0b102e891f149647b162897bf4403f8f66c
+PKG_MIRROR_HASH:=8017fd769d8128af5b54ce7935f4801cc798c6608dd54fa3e3a7d230ec8f1b64
 
 PKG_MAINTAINER:=Nick Peng <pymumu@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later


### PR DESCRIPTION

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:  https://github.com/openwrt/packages/commit/c4ef81e8293c1dfc530b49102adfb6c381e11916

