### PR TITLE
qttools: remove the url that caused the downloads to fail

### DIFF
--- a/libs/qttools/Makefile
+++ b/libs/qttools/Makefile
@@ -14,7 +14,6 @@ PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-everywhere-opensource-src-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
-		http://download.qt.io/official_releases/qt/$(PKG_BASE)/$(PKG_VERSION)/submodules \
 		http://master.qt.io/archive/qt/$(PKG_BASE)/$(PKG_VERSION)/submodules \
 		http://mirrors.tuna.tsinghua.edu.cn/qt/archive/qt/$(PKG_BASE)/$(PKG_VERSION)/submodules \
 		http://qt.mirror.constant.com/archive/qt/$(PKG_BASE)/$(PKG_VERSION)/submodules


### PR DESCRIPTION
2022-10-02T05:58:42.0628939Z 
2022-10-02T05:58:42.0630827Z 10/02 05:58:42 [[1;32mNOTICE[0m] CUID#7 - Redirecting to https://download.qt.io/official_releases/qt/5.15/5.15.4/submodules/qttools-everywhere-opensource-src-5.15.4.tar.xz
2022-10-02T05:58:42.4746198Z 
2022-10-02T05:58:42.4747473Z 10/02 05:58:42 [[1;32mNOTICE[0m] Download complete: /home/runner/work/OpenWrt_Build/OpenWrt_Build/openwrt/tmp/aria2c/qttools-everywhere-opensource-src-5.15.4.tar.xz_CofVxWQbOE
2022-10-02T05:58:42.7582351Z [#12ca03 720KiB/8.4MiB(8%) CN:8 DL:9.9MiB]
2022-10-02T05:58:43.7618575Z [#12ca03 6.5MiB/8.4MiB(77%) CN:3 DL:6.1MiB]
2022-10-02T05:58:44.7773775Z [#12ca03 7.9MiB/8.4MiB(93%) CN:2 DL:3.8MiB]
2022-10-02T05:58:45.1921399Z 
2022-10-02T05:58:45.1922834Z 10/02 05:58:45 [[1;32mNOTICE[0m] Download complete: /home/runner/work/OpenWrt_Build/OpenWrt_Build/openwrt/tmp/aria2c/qttools-everywhere-opensource-src-5.15.4.tar.xz
2022-10-02T05:58:45.1935237Z 
2022-10-02T05:58:45.1936266Z 10/02 05:58:45 [[1;32mNOTICE[0m] ServerStat file /home/runner/work/OpenWrt_Build/OpenWrt_Build/openwrt/tmp/aria2c/qttools-everywhere-opensource-src-5.15.4.tar.xz_CofVxWQbOE_spp saved successfully.
2022-10-02T05:58:45.1936939Z 
2022-10-02T05:58:45.1937114Z Download Results:
2022-10-02T05:58:45.1937695Z gid   |stat|avg speed  |path/URI
2022-10-02T05:58:45.1938023Z ======+====+===========+=======================================================
2022-10-02T05:58:45.1939002Z 7c72eb|OK  |   2.9MiB/s|/home/runner/work/OpenWrt_Build/OpenWrt_Build/openwrt/tmp/aria2c/qttools-everywhere-opensource-src-5.15.4.tar.xz_CofVxWQbOE
2022-10-02T05:58:45.1949012Z 12ca03|OK  |   3.1MiB/s|/home/runner/work/OpenWrt_Build/OpenWrt_Build/openwrt/tmp/aria2c/qttools-everywhere-opensource-src-5.15.4.tar.xz
2022-10-02T05:58:45.1949432Z 
2022-10-02T05:58:45.1949574Z Status Legend:
2022-10-02T05:58:45.1949868Z (OK):download completed.
2022-10-02T05:58:45.2029469Z Hash of the downloaded file does not match (file: 154cad5b8f79d9dd6eb3f62c9412621de5c805b266dc1d6e4b5525ebcb030ee9, requested: 4c5ccf8fdae70f3d4c731419935f456203950f9f4fce325d81b686f05e60b333) - deleting download.
2022-10-02T05:58:45.2057043Z No more mirrors to try - giving up.
2022-10-02T05:58:45.2057576Z make[3]: Leaving directory '/home/runner/work/OpenWrt_Build/OpenWrt_Build/openwrt/feeds/packages/libs/qttools'
2022-10-02T05:58:45.2059333Z make[3]: *** [Makefile:52: /home/runner/work/OpenWrt_Build/OpenWrt_Build/openwrt/dl/qttools-everywhere-opensource-src-5.15.4.tar.xz] Error 2
2022-10-02T05:58:45.2059806Z time: package/feeds/packages/qttools/compile#0.26#0.10#4.23
2022-10-02T05:58:45.2063700Z     ERROR: package/feeds/packages/qttools failed to build.

同qtbase，会报错，所以去掉。
