### PR TITLE
uugamebooster bump to v3.0.4

### DIFF
--- a/net/uugamebooster/Makefile
+++ b/net/uugamebooster/Makefile
@@ -12,7 +12,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uugamebooster
-PKG_VERSION:=v2.24.12
+PKG_VERSION:=v3.0.4
 PKG_RELEASE:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -31,22 +31,22 @@ endef
 
 ifeq ($(ARCH),arm)
 	UU_ARCH:=arm
-	PKG_MD5SUM:=5926cf8c18aca92f8a6304c47739c226
+	PKG_MD5SUM:=275c903b5cc9d4a734d2a50fd729838f
 endif
 
 ifeq ($(ARCH),aarch64)
 	UU_ARCH:=aarch64
-	PKG_MD5SUM:=8a08b04960e7428d08cb13d8f9aaf962
+	PKG_MD5SUM:=0c688bb10472564e73f3ba7cd721ce20
 endif
 
 ifeq ($(ARCH),mipsel)
 	UU_ARCH:=mipsel
-	PKG_MD5SUM:=b878586944e92ea94ba57c45b063e80b
+	PKG_MD5SUM:=645da157d7c291cfb5b8e87f08a182b6
 endif
 
 ifeq ($(ARCH),x86_64)
 	UU_ARCH:=x86_64
-	PKG_MD5SUM:=78786fc3bc9bd411a908ddc527c35d21
+	PKG_MD5SUM:=00b35eca6dc0a124431ab8dc9c21c8a1
 endif
 
 PKG_SOURCE_URL:=https://uu.gdl.netease.com/uuplugin/openwrt-$(UU_ARCH)/$(PKG_VERSION)/uu.tar.gz?


### PR DESCRIPTION
Maintainer: me / @<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
aarch64_cortex-a53

Run tested: (put here arch, model, OpenWrt version, tests done)
aarch64, QSDK, OpenWrt R22.8.22, testing passed

Description:
uugamebooster bump to v3.0.4