### PR TITLE
ffmpeg: libffmpeg-full package should provide libffmpeg package, too

### DIFF
--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -352,7 +352,7 @@ $(call Package/libffmpeg/Default)
     +PACKAGE_libx264:libx264 \
     +!PACKAGE_libx264:fdk-aac
  VARIANT:=full
- PROVIDES:=libffmpeg-mini libffmpeg-audio-dec
+ PROVIDES+=libffmpeg-mini libffmpeg-audio-dec
 endef
 
 


### PR DESCRIPTION
The previous solution overwrote the provide from ``define Package/libffmpeg/Default``, but that's not what was wanted. Thus libffmpeg-full should provide three packages libffmpeg, libffmpeg-mini and libffmpeg-audio-dec

Signed-off-by: Josef Schlehofer <pepe.schlehofer@gmail.com>
