### PR TITLE
sqlite3: Update to 3.40.0

### DIFF
--- a/libs/sqlite3/Config-lib.in
+++ b/libs/sqlite3/Config-lib.in
@@ -7,6 +7,13 @@ config SQLITE3_BATCH_ATOMIC_WRITE
 	help
 	  Enable batch-atomic write optimization (supported only on F2FS).
 
+config SQLITE3_COLUMN_METADATA
+	bool "Column metadata API extensions"
+	default y
+	help
+	  Includes some additional APIs that provide convenient access to
+	  meta-data about tables and queries.
+
 config SQLITE3_DYNAMIC_EXTENSIONS
 	bool "Dynamic extensions"
 	default y

--- a/libs/sqlite3/Makefile
+++ b/libs/sqlite3/Makefile
@@ -8,30 +8,26 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sqlite
-PKG_VERSION:=3370000
+PKG_VERSION:=3400000
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-autoconf-$(PKG_VERSION).tar.gz
-PKG_HASH:=731a4651d4d4b36fc7d21db586b2de4dd00af31fd54fb5a9a4b7f492057479f7
-PKG_SOURCE_URL:=https://www.sqlite.org/2021/
+PKG_SOURCE_URL:=https://www.sqlite.org/2022/
+PKG_HASH:=0333552076d2700c75352256e91c78bf5cd62491589ba0c69aed0a81868980e7
 
+PKG_CPE_ID:=cpe:/a:sqlite:sqlite
 PKG_LICENSE:=PUBLICDOMAIN
 PKG_LICENSE_FILES:=
-
 PKG_MAINTAINER:=
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-autoconf-$(PKG_VERSION)
-
 PKG_BUILD_PARALLEL:=1
-
-PKG_CPE_ID:=cpe:/a:sqlite:sqlite
-
 PKG_FIXUP:=autoreconf
-
 PKG_INSTALL:=1
 
 PKG_CONFIG_DEPENDS := \
 	CONFIG_SQLITE3_BATCH_ATOMIC_WRITE \
+	CONFIG_SQLITE3_COLUMN_METADATA \
 	CONFIG_SQLITE3_DYNAMIC_EXTENSIONS \
 	CONFIG_SQLITE3_FTS3 \
 	CONFIG_SQLITE3_FTS4 \
@@ -101,7 +97,8 @@ TARGET_CFLAGS += \
 	-DHAVE_ISNAN \
 	-DHAVE_MALLOC_USABLE_SIZE \
 	-DSQLITE_ENABLE_UNLOCK_NOTIFY \
-	$(if $(CONFIG_SQLITE3_BATCH_ATOMIC_WRITE),-DSQLITE_ENABLE_BATCH_ATOMIC_WRITE)
+	$(if $(CONFIG_SQLITE3_BATCH_ATOMIC_WRITE),-DSQLITE_ENABLE_BATCH_ATOMIC_WRITE) \
+	$(if $(CONFIG_SQLITE3_COLUMN_METADATA),-DSQLITE_ENABLE_COLUMN_METADATA)
 
 CONFIGURE_ARGS += \
 	--disable-debug \
@@ -111,8 +108,8 @@ CONFIGURE_ARGS += \
 	--enable-threadsafe \
 	$(if $(CONFIG_SQLITE3_DYNAMIC_EXTENSIONS),--enable-dynamic-extensions,--disable-dynamic-extensions) \
 	$(if $(CONFIG_SQLITE3_FTS3),--enable-fts3,--disable-fts3) \
-	$(if $(CONFIG_SQLITE3_FTS3),--enable-fts4,--disable-fts4) \
-	$(if $(CONFIG_SQLITE3_FTS3),--enable-fts5,--disable-fts5) \
+	$(if $(CONFIG_SQLITE3_FTS4),--enable-fts4,--disable-fts4) \
+	$(if $(CONFIG_SQLITE3_FTS5),--enable-fts5,--disable-fts5) \
 	$(if $(CONFIG_SQLITE3_JSON1),--enable-json1,--disable-json1) \
 	$(if $(CONFIG_SQLITE3_RTREE),--enable-rtree,--disable-rtree) \
 	$(if $(CONFIG_SQLITE3_SESSION),--enable-session,--disable-session)


### PR DESCRIPTION
1. Added a new option for SQLITE3_COLUMN_METADATA.
2. Minor cleanup Makefile and fixed 2 typo errors.

Fixes: CVE-2022-35737

Signed-off-by: Tianling Shen <cnsztl@immortalwrt.org>
