### PR TITLE
fix iperf3 ifeq compile error

### DIFF
--- a/net/iperf3/Makefile
+++ b/net/iperf3/Makefile
@@ -56,7 +56,7 @@ endef
 
 TARGET_CFLAGS += -D_GNU_SOURCE
 
-ifeq ($(BUILD_VARIANT),ssl)
+ifeq ($(BUILD_VARIANT), ssl)
 	CONFIGURE_ARGS += --with-openssl="$(STAGING_DIR)/usr" --disable-shared
 else
 	CONFIGURE_ARGS += --without-openssl


### PR DESCRIPTION
Compile tested:   ubuntu22.04
Run tested: Intel(R) Xeon(R) Gold 6133 CPU @ 2.50GHz

Description:
解决编译iperf3时报的ifeq问题