### PR TITLE
php7: fixup libiconv usage

### DIFF
--- a/lang/php7/Makefile
+++ b/lang/php7/Makefile
@@ -254,7 +254,13 @@ else
 endif
 
 ifneq ($(SDK)$(CONFIG_PACKAGE_php7-mod-iconv),)
-  CONFIGURE_ARGS+= --with-iconv=shared,"$(ICONV_PREFIX)"
+  ifeq ($(CONFIG_BUILD_NLS),y)
+    CONFIGURE_VARS+= iconv_impl_name="gnu_libiconv"
+    CONFIGURE_ARGS+= --with-iconv=shared,"$(ICONV_PREFIX)"
+  else
+    CONFIGURE_VARS+= ac_cv_func_iconv=yes
+    CONFIGURE_ARGS+= --with-iconv=shared
+  endif
 else
   CONFIGURE_ARGS+= --without-iconv
 endif
@@ -471,7 +477,6 @@ endif
 CONFIGURE_VARS+= \
 	ac_cv_c_bigendian_php=$(if $(CONFIG_BIG_ENDIAN),yes,no) \
 	php_cv_cc_rpath="no" \
-	iconv_impl_name="gnu_libiconv" \
 	ac_cv_php_xml2_config_path="$(STAGING_DIR)/host/bin/xml2-config" \
 	ac_cv_u8t_decompose=yes \
 	ac_cv_have_pcre2_jit=no


### PR DESCRIPTION
Since the OpenWrt's stub libiconv implementation is now gone, we can build against musl's internal one or the external libiconv implementation.
This needs minor adjustements in the makefile to allow PHPs build to choose the right path when cross-compiling.

Fixes: https://github.com/coolsnowwolf/lede/issues/10805

Signed-off-by: Michael Heimpold <mhei@heimpold.de>