### PR TITLE
copy pam_oath.so

### DIFF
--- a/utils/oath-toolkit/Makefile
+++ b/utils/oath-toolkit/Makefile
@@ -46,9 +46,10 @@ endef
 
 define Package/oath-toolkit/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_DIR) $(1)/usr/lib $(1)/usr/lib/security
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/oathtool $(1)/usr/bin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/liboath.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/security/*.so* $(1)/usr/lib/security/
 endef
 
 $(eval $(call BuildPackage,oath-toolkit))

--- a/utils/oath-toolkit/Makefile
+++ b/utils/oath-toolkit/Makefile
@@ -34,7 +34,7 @@ define Package/oath-toolkit
   CATEGORY:=Utilities
   TITLE:=Toolkit for building one-time password authentication
   URL:=http://www.nongnu.org/oath-toolkit/index.html
-  DEPENDS:=
+  DEPENDS:= +libpam
 endef
 
 define Package/oath-toolkit/description


### PR DESCRIPTION
pam_oath.so can be used by openconnect with OATH two factor authentication. See https://ocserv.gitlab.io/www/recipes-ocserv-2fa.html