### PR TITLE
pgyvpn: Fix vncinit parameter error (use `-C`)

### DIFF
--- a/net/pgyvpn/files/etc/init.d/pgyvpn
+++ b/net/pgyvpn/files/etc/init.d/pgyvpn
@@ -86,7 +86,7 @@ start_service()
 	cmd_arg="$cmd_arg --logsize 4194304 --logpath $log_path --logmask $log_mask"
 	cmd_arg="$cmd_arg --orayslpath $oraysl_filename --oraysllogpath $oraysl_logpath --orayslstatusfilename $oraysl_statusfilename --orayslpidfilename $oraysl_pidfilename"
 	[ -n "$script_p2pinit" ] && cmd_arg="$cmd_arg -n $script_p2pinit"
-	[ -n "$script_vncinit" ] && cmd_arg="$cmd_arg -n $script_vncinit"
+	[ -n "$script_vncinit" ] && cmd_arg="$cmd_arg -C $script_vncinit"
 	# [ -n "$script_progress" ] && cmd_arg="$cmd_arg -n $script_progress"
 	[ -n "$script_progress" ] && cmd_arg="$cmd_arg -N $script_progress"
 	[ -n "$local_ip" ] && cmd_arg="$cmd_arg --localip $local_ip"


### PR DESCRIPTION
Maintainer: @aiamadeus
Compile tested: x86-64 ImmortalWrt SNAPSHOT 
Run tested: x86-64 ImmortalWrt SNAPSHOT 

Description:
Running vncinit script should use `-C` instead of `-n`