### PR TITLE
aria2:fix ssl errors

### DIFF
--- a/net/aria2/files/aria2.init
+++ b/net/aria2/files/aria2.init
@@ -105,7 +105,7 @@ aria2_validate() {
 		'bt_seed_unverified:or("true","false")' \
 		'bt_stop_timeout:uinteger' \
 		'bt_tracker:list(string)' \
-		'ca_certificate:file' \
+		'ca_certificate:string:/etc/ssl/certs/ca-certificates.crt' \
 		'certificate:file' \
 		'check_certificate:or("true","false"):true' \
 		'check_integrity:or("true","false")' \


### PR DESCRIPTION
Maintainer: @coolsnowwolf 
Compile tested: x86 aarch64
Run tested: x86,OpenWRT R23.5.1
Description:
aira2 下载 https网站的文件的时候会发生‘SSL/TLS handshake failure: unable to get local issuer certificate’这个问题，查证后发现是没有加载正确的ca-certificate导致的，在x86和arm64中测试过了，可以解决这个问题;
同时可能要将ca-certificate设置成aria2的依赖
