### PR TITLE
htop: enable unicode.

### DIFF
--- a/admin/htop/Makefile
+++ b/admin/htop/Makefile
@@ -60,7 +60,7 @@ CONFIGURE_ARGS += \
 	--enable-affinity \
 	--disable-capabilities \
 	--disable-delayacct \
-	--disable-unicode \
+	--enable-unicode \
 	--disable-unwind \
 	--disable-hwloc
 


### PR DESCRIPTION
Maintainer: Etienne CHAMPETIER <champetier.etienne@gmail.com>
Compile tested: 
```
make package/feeds/packages/htop/compile V=s                 
make[2]: Entering directory '/home/evine/lede/scripts/config'
make[2]: 'conf' is up to date.
make[2]: Leaving directory '/home/evine/lede/scripts/config'
make[1]: Entering directory '/home/evine/lede'
make[2]: Entering directory '/home/evine/lede/package/libs/ncurses'
make[2]: Leaving directory '/home/evine/lede/package/libs/ncurses'
time: package/libs/ncurses/host-compile#0.11#0.03#0.13
make[2]: Entering directory '/home/evine/lede/package/libs/toolchain'
echo "libc" >> /home/evine/lede/staging_dir/target-x86_64_musl/pkginfo/toolchain.default.install
echo "libgcc" >> /home/evine/lede/staging_dir/target-x86_64_musl/pkginfo/toolchain.default.install
echo "libatomic" >> /home/evine/lede/staging_dir/target-x86_64_musl/pkginfo/toolchain.default.install
echo "libstdcpp" >> /home/evine/lede/staging_dir/target-x86_64_musl/pkginfo/toolchain.default.install
echo "libpthread" >> /home/evine/lede/staging_dir/target-x86_64_musl/pkginfo/toolchain.default.install
echo "librt" >> /home/evine/lede/staging_dir/target-x86_64_musl/pkginfo/toolchain.default.install
make[2]: Leaving directory '/home/evine/lede/package/libs/toolchain'
time: package/libs/toolchain/compile#0.09#0.02#0.11
make[2]: Entering directory '/home/evine/lede/package/libs/zlib'
echo "zlib" >> /home/evine/lede/staging_dir/target-x86_64_musl/pkginfo/zlib.default.install
make[2]: Leaving directory '/home/evine/lede/package/libs/zlib'
time: package/libs/zlib/compile#0.15#0.03#0.17
make[2]: Entering directory '/home/evine/lede/package/libs/ncurses'
echo "terminfo" >> /home/evine/lede/staging_dir/target-x86_64_musl/pkginfo/ncurses.default.install
echo "libncurses" >> /home/evine/lede/staging_dir/target-x86_64_musl/pkginfo/ncurses.default.install
make[2]: Leaving directory '/home/evine/lede/package/libs/ncurses'
time: package/libs/ncurses/compile#0.14#0.03#0.22
make[2]: Entering directory '/home/evine/lede/package/libs/sysfsutils'
echo "libsysfs" >> /home/evine/lede/staging_dir/target-x86_64_musl/pkginfo/sysfsutils.default.install
echo "sysfsutils" >> /home/evine/lede/staging_dir/target-x86_64_musl/pkginfo/sysfsutils.default.install
make[2]: Leaving directory '/home/evine/lede/package/libs/sysfsutils'
time: package/libs/sysfsutils/compile#0.09#0.03#0.11
make[2]: Entering directory '/home/evine/lede/feeds/packages/utils/lm-sensors'
echo "libsensors" >> /home/evine/lede/staging_dir/target-x86_64_musl/pkginfo/lm-sensors.default.install
echo "lm-sensors" >> /home/evine/lede/staging_dir/target-x86_64_musl/pkginfo/lm-sensors.default.install
make[2]: Leaving directory '/home/evine/lede/feeds/packages/utils/lm-sensors'
time: package/feeds/packages/lm-sensors/compile#0.10#0.01#0.11
make[2]: Entering directory '/home/evine/lede/feeds/packages/admin/htop'
echo "htop" >> /home/evine/lede/staging_dir/target-x86_64_musl/pkginfo/htop.default.install
make[2]: Leaving directory '/home/evine/lede/feeds/packages/admin/htop'
time: package/feeds/packages/htop/compile#0.10#0.01#0.11
make[1]: Leaving directory '/home/evine/lede'
```
Run tested: No errors.
Description: htop: enable unicode.
