### PR TITLE
mosdns: sync with upstream

### DIFF
--- a/net/mosdns/patches/100-update-deps.patch
+++ b/net/mosdns/patches/100-update-deps.patch
@@ -1,0 +1,483 @@
+From 1a5d1bbc33a20856d20b3935338c279ee9aae584 Mon Sep 17 00:00:00 2001
+From: sbwml <admin@cooluc.com>
+Date: Fri, 25 Aug 2023 09:19:37 +0800
+Subject: [PATCH] update dependencies & quic-go v0.38.1
+
+---
+ go.mod                             |  66 +++++++------
+ go.sum                             | 149 ++++++++++++++---------------
+ pkg/server/http_handler/handler.go |   1 +
+ pkg/upstream/upstream.go           |  23 +++--
+ 4 files changed, 119 insertions(+), 120 deletions(-)
+
+diff --git a/go.mod b/go.mod
+index 2212cd3..1a1dd43 100644
+--- a/go.mod
++++ b/go.mod
+@@ -3,26 +3,26 @@ module github.com/IrineSistiana/mosdns/v5
+ go 1.19
+ 
+ require (
+-	github.com/go-chi/chi/v5 v5.0.8
++	github.com/go-chi/chi/v5 v5.0.10
+ 	github.com/google/nftables v0.1.0
+ 	github.com/kardianos/service v1.2.2
+-	github.com/klauspost/compress v1.16.3
+-	github.com/miekg/dns v1.1.52
++	github.com/klauspost/compress v1.16.7
++	github.com/miekg/dns v1.1.55
+ 	github.com/mitchellh/mapstructure v1.5.0
+ 	github.com/nadoo/ipset v0.5.0
+-	github.com/prometheus/client_golang v1.14.0
+-	github.com/quic-go/quic-go v0.33.0
+-	github.com/spf13/cobra v1.6.1
+-	github.com/spf13/viper v1.15.0
+-	github.com/stretchr/testify v1.8.1
++	github.com/prometheus/client_golang v1.16.0
++	github.com/quic-go/quic-go v0.38.1
++	github.com/spf13/cobra v1.7.0
++	github.com/spf13/viper v1.16.0
++	github.com/stretchr/testify v1.8.4
+ 	github.com/vishvananda/netlink v1.2.1-beta.2.0.20221107222636-d3c0a2caa559
+-	go.uber.org/zap v1.24.0
+-	go4.org/netipx v0.0.0-20230303233057-f1b76eb4bb35
+-	golang.org/x/exp v0.0.0-20230314191032-db074128a8ec
+-	golang.org/x/net v0.8.0
+-	golang.org/x/sync v0.1.0
+-	golang.org/x/sys v0.6.0
+-	google.golang.org/protobuf v1.29.1
++	go.uber.org/zap v1.25.0
++	go4.org/netipx v0.0.0-20230824141953-6213f710f925
++	golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63
++	golang.org/x/net v0.14.0
++	golang.org/x/sync v0.3.0
++	golang.org/x/sys v0.11.0
++	google.golang.org/protobuf v1.31.0
+ )
+ 
+ replace github.com/nadoo/ipset v0.5.0 => github.com/IrineSistiana/ipset v0.5.1-0.20220703061533-6e0fc3b04c0a
+@@ -32,39 +32,37 @@ require (
+ 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+ 	github.com/davecgh/go-spew v1.1.1 // indirect
+ 	github.com/fsnotify/fsnotify v1.6.0 // indirect
+-	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
++	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
+ 	github.com/golang/mock v1.6.0 // indirect
+ 	github.com/golang/protobuf v1.5.3 // indirect
+ 	github.com/google/go-cmp v0.5.9 // indirect
+-	github.com/google/pprof v0.0.0-20230309165930-d61513b1440d // indirect
++	github.com/google/pprof v0.0.0-20230821062121-407c9e7a662f // indirect
+ 	github.com/hashicorp/hcl v1.0.0 // indirect
+ 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+ 	github.com/josharian/native v1.1.0 // indirect
+ 	github.com/magiconair/properties v1.8.7 // indirect
+ 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
+-	github.com/mdlayher/netlink v1.7.1 // indirect
+-	github.com/mdlayher/socket v0.4.0 // indirect
+-	github.com/onsi/ginkgo/v2 v2.9.1 // indirect
+-	github.com/pelletier/go-toml/v2 v2.0.7 // indirect
++	github.com/mdlayher/netlink v1.7.2 // indirect
++	github.com/mdlayher/socket v0.4.1 // indirect
++	github.com/onsi/ginkgo/v2 v2.12.0 // indirect
++	github.com/pelletier/go-toml/v2 v2.0.9 // indirect
+ 	github.com/pmezard/go-difflib v1.0.0 // indirect
+-	github.com/prometheus/client_model v0.3.0 // indirect
+-	github.com/prometheus/common v0.42.0 // indirect
+-	github.com/prometheus/procfs v0.9.0 // indirect
++	github.com/prometheus/client_model v0.4.0 // indirect
++	github.com/prometheus/common v0.44.0 // indirect
++	github.com/prometheus/procfs v0.11.1 // indirect
+ 	github.com/quic-go/qpack v0.4.0 // indirect
+-	github.com/quic-go/qtls-go1-19 v0.2.1 // indirect
+-	github.com/quic-go/qtls-go1-20 v0.1.1 // indirect
++	github.com/quic-go/qtls-go1-20 v0.3.3 // indirect
+ 	github.com/spf13/afero v1.9.5 // indirect
+-	github.com/spf13/cast v1.5.0 // indirect
++	github.com/spf13/cast v1.5.1 // indirect
+ 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+ 	github.com/spf13/pflag v1.0.5 // indirect
+-	github.com/subosito/gotenv v1.4.2 // indirect
++	github.com/subosito/gotenv v1.6.0 // indirect
+ 	github.com/vishvananda/netns v0.0.1 // indirect
+-	go.uber.org/atomic v1.10.0 // indirect
+-	go.uber.org/multierr v1.10.0 // indirect
+-	golang.org/x/crypto v0.7.0 // indirect
+-	golang.org/x/mod v0.9.0 // indirect
+-	golang.org/x/text v0.8.0 // indirect
+-	golang.org/x/tools v0.7.0 // indirect
++	go.uber.org/multierr v1.11.0 // indirect
++	golang.org/x/crypto v0.12.0 // indirect
++	golang.org/x/mod v0.12.0 // indirect
++	golang.org/x/text v0.12.0 // indirect
++	golang.org/x/tools v0.12.1-0.20230815132531-74c255bcf846 // indirect
+ 	gopkg.in/ini.v1 v1.67.0 // indirect
+ 	gopkg.in/yaml.v3 v3.0.1 // indirect
+ )
+diff --git a/go.sum b/go.sum
+index 960ad98..59c420f 100644
+--- a/go.sum
++++ b/go.sum
+@@ -40,7 +40,7 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
+ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+ github.com/IrineSistiana/ipset v0.5.1-0.20220703061533-6e0fc3b04c0a h1:GQdh/h0q0ni3L//CXusyk+7QdhBL289vdNaes1WKkHI=
+ github.com/IrineSistiana/ipset v0.5.1-0.20220703061533-6e0fc3b04c0a/go.mod h1:rYF5DQLRGGoQ8ZSWeK+6eX5amAuPqwFkWjhQlEITGJQ=
+-github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
++github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
+ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+@@ -63,17 +63,17 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
+ github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
+ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
+ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+-github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
++github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
+ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+ github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
+-github.com/go-chi/chi/v5 v5.0.8 h1:lD+NLqFcAi1ovnVZpsnObHGW4xb4J8lNmoYVfECH1Y0=
+-github.com/go-chi/chi/v5 v5.0.8/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
++github.com/go-chi/chi/v5 v5.0.10 h1:rLz5avzKpjqxrYwXNfmjkrYYXOyLJd37pz53UFHC6vk=
++github.com/go-chi/chi/v5 v5.0.10/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+ github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
+ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+-github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
+-github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
+-github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
++github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
++github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
++github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
+ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+ github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+ github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+@@ -133,8 +133,8 @@ github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hf
+ github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+ github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+ github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+-github.com/google/pprof v0.0.0-20230309165930-d61513b1440d h1:um9/pc7tKMINFfP1eE7Wv6PRGXlcCSJkVajF7KJw3uQ=
+-github.com/google/pprof v0.0.0-20230309165930-d61513b1440d/go.mod h1:79YE0hCXdHag9sBkw2o+N/YnZtTkXi0UT9Nnixa5eYk=
++github.com/google/pprof v0.0.0-20230821062121-407c9e7a662f h1:pDhu5sgp8yJlEF/g6osliIIpF9K4F5jvkULXa4daRDQ=
++github.com/google/pprof v0.0.0-20230821062121-407c9e7a662f/go.mod h1:czg5+yv1E0ZGTi6S6vVK1mke0fV+FaUhNGcd6VRS9Ik=
+ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
+@@ -146,7 +146,6 @@ github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
+ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+-github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+ github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+ github.com/josharian/native v1.1.0 h1:uuaP0hAbW7Y4l0ZRQ6C9zfb7Mg1mbFKry/xzDAfmtLA=
+@@ -156,11 +155,11 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
+ github.com/kardianos/service v1.2.2 h1:ZvePhAHfvo0A7Mftk/tEzqEZ7Q4lgnR8sGz4xu1YX60=
+ github.com/kardianos/service v1.2.2/go.mod h1:CIMRFEJVL+0DS1a3Nx06NaMn4Dz63Ng6O7dl0qH0zVM=
+ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+-github.com/klauspost/compress v1.16.3 h1:XuJt9zzcnaz6a16/OU53ZjWp/v7/42WcR5t2a0PcNQY=
+-github.com/klauspost/compress v1.16.3/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
++github.com/klauspost/compress v1.16.7 h1:2mk3MPGNzKyxErAw8YaohYh69+pa4sIQSC0fPGCFR9I=
++github.com/klauspost/compress v1.16.7/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
+ github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
+ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+-github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
++github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+@@ -168,69 +167,67 @@ github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0V
+ github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
+ github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
+ github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+-github.com/mdlayher/netlink v1.7.1 h1:FdUaT/e33HjEXagwELR8R3/KL1Fq5x3G5jgHLp/BTmg=
+-github.com/mdlayher/netlink v1.7.1/go.mod h1:nKO5CSjE/DJjVhk/TNp6vCE1ktVxEA8VEh8drhZzxsQ=
+-github.com/mdlayher/socket v0.4.0 h1:280wsy40IC9M9q1uPGcLBwXpcTQDtoGwVt+BNoITxIw=
+-github.com/mdlayher/socket v0.4.0/go.mod h1:xxFqz5GRCUN3UEOm9CZqEJsAbe1C8OwSK46NlmWuVoc=
+-github.com/miekg/dns v1.1.52 h1:Bmlc/qsNNULOe6bpXcUTsuOajd0DzRHwup6D9k1An0c=
+-github.com/miekg/dns v1.1.52/go.mod h1:uInx36IzPl7FYnDcMeVWxj9byh7DutNykX4G9Sj60FY=
++github.com/mdlayher/netlink v1.7.2 h1:/UtM3ofJap7Vl4QWCPDGXY8d3GIY2UGSDbK+QWmY8/g=
++github.com/mdlayher/netlink v1.7.2/go.mod h1:xraEF7uJbxLhc5fpHL4cPe221LI2bdttWlU+ZGLfQSw=
++github.com/mdlayher/socket v0.4.1 h1:eM9y2/jlbs1M615oshPQOHZzj6R6wMT7bX5NPiQvn2U=
++github.com/mdlayher/socket v0.4.1/go.mod h1:cAqeGjoufqdxWkD7DkpyS+wcefOtmu5OQ8KuoJGIReA=
++github.com/miekg/dns v1.1.55 h1:GoQ4hpsj0nFLYe+bWiCToyrBEJXkQfOOIvFGFy0lEgo=
++github.com/miekg/dns v1.1.55/go.mod h1:uInx36IzPl7FYnDcMeVWxj9byh7DutNykX4G9Sj60FY=
+ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+ github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+-github.com/onsi/ginkgo/v2 v2.9.1 h1:zie5Ly042PD3bsCvsSOPvRnFwyo3rKe64TJlD6nu0mk=
+-github.com/onsi/ginkgo/v2 v2.9.1/go.mod h1:FEcmzVcCHl+4o9bQZVab+4dC9+j+91t2FHSzmGAPfuo=
+-github.com/onsi/gomega v1.27.3 h1:5VwIwnBY3vbBDOJrNtA4rVdiTZCsq9B5F12pvy1Drmk=
+-github.com/pelletier/go-toml/v2 v2.0.7 h1:muncTPStnKRos5dpVKULv2FVd4bMOhNePj9CjgDb8Us=
+-github.com/pelletier/go-toml/v2 v2.0.7/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
+-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
++github.com/onsi/ginkgo/v2 v2.12.0 h1:UIVDowFPwpg6yMUpPjGkYvf06K3RAiJXUhCxEwQVHRI=
++github.com/onsi/ginkgo/v2 v2.12.0/go.mod h1:ZNEzXISYlqpb8S36iN71ifqLi3vVD1rVJGvWRCJOUpQ=
++github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
++github.com/pelletier/go-toml/v2 v2.0.9 h1:uH2qQXheeefCCkuBBSLi7jCiSmj3VRh2+Goq2N7Xxu0=
++github.com/pelletier/go-toml/v2 v2.0.9/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
+ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+ github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
+ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+-github.com/prometheus/client_golang v1.14.0 h1:nJdhIvne2eSX/XRAFV9PcvFFRbrjbcTUj0VP62TMhnw=
+-github.com/prometheus/client_golang v1.14.0/go.mod h1:8vpkKitgIVNcqrRBWh1C4TIUQgYNtG/XQE4E/Zae36Y=
++github.com/prometheus/client_golang v1.16.0 h1:yk/hx9hDbrGHovbci4BY+pRMfSuuat626eFsHb7tmT8=
++github.com/prometheus/client_golang v1.16.0/go.mod h1:Zsulrv/L9oM40tJ7T815tM89lFEugiJ9HzIqaAx4LKc=
+ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+-github.com/prometheus/client_model v0.3.0 h1:UBgGFHqYdG/TPFD1B1ogZywDqEkwp3fBMvqdiQ7Xew4=
+-github.com/prometheus/client_model v0.3.0/go.mod h1:LDGWKZIo7rky3hgvBe+caln+Dr3dPggB5dvjtD7w9+w=
+-github.com/prometheus/common v0.42.0 h1:EKsfXEYo4JpWMHH5cg+KOUWeuJSov1Id8zGR8eeI1YM=
+-github.com/prometheus/common v0.42.0/go.mod h1:xBwqVerjNdUDjgODMpudtOMwlOwf2SaTr1yjz4b7Zbc=
+-github.com/prometheus/procfs v0.9.0 h1:wzCHvIvM5SxWqYvwgVL7yJY8Lz3PKn49KQtpgMYJfhI=
+-github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB/chUwxUZY=
++github.com/prometheus/client_model v0.4.0 h1:5lQXD3cAg1OXBf4Wq03gTrXHeaV0TQvGfUooCfx1yqY=
++github.com/prometheus/client_model v0.4.0/go.mod h1:oMQmHW1/JoDwqLtg57MGgP/Fb1CJEYF2imWWhWtMkYU=
++github.com/prometheus/common v0.44.0 h1:+5BrQJwiBB9xsMygAB3TNvpQKOwlkc25LbISbrdOOfY=
++github.com/prometheus/common v0.44.0/go.mod h1:ofAIvZbQ1e/nugmZGz4/qCb9Ap1VoSTIO7x0VV9VvuY=
++github.com/prometheus/procfs v0.11.1 h1:xRC8Iq1yyca5ypa9n1EZnWZkt7dwcoRPQwX/5gwaUuI=
++github.com/prometheus/procfs v0.11.1/go.mod h1:eesXgaPo1q7lBpVMoMy0ZOFTth9hBn4W/y0/p/ScXhY=
+ github.com/quic-go/qpack v0.4.0 h1:Cr9BXA1sQS2SmDUWjSofMPNKmvF6IiIfDRmgU0w1ZCo=
+ github.com/quic-go/qpack v0.4.0/go.mod h1:UZVnYIfi5GRk+zI9UMaCPsmZ2xKJP7XBUvVyT1Knj9A=
+-github.com/quic-go/qtls-go1-19 v0.2.1 h1:aJcKNMkH5ASEJB9FXNeZCyTEIHU1J7MmHyz1Q1TSG1A=
+-github.com/quic-go/qtls-go1-19 v0.2.1/go.mod h1:ySOI96ew8lnoKPtSqx2BlI5wCpUVPT05RMAlajtnyOI=
+-github.com/quic-go/qtls-go1-20 v0.1.1 h1:KbChDlg82d3IHqaj2bn6GfKRj84Per2VGf5XV3wSwQk=
+-github.com/quic-go/qtls-go1-20 v0.1.1/go.mod h1:JKtK6mjbAVcUTN/9jZpvLbGxvdWIKS8uT7EiStoU1SM=
+-github.com/quic-go/quic-go v0.33.0 h1:ItNoTDN/Fm/zBlq769lLJc8ECe9gYaW40veHCCco7y0=
+-github.com/quic-go/quic-go v0.33.0/go.mod h1:YMuhaAV9/jIu0XclDXwZPAsP/2Kgr5yMYhe9oxhhOFA=
++github.com/quic-go/qtls-go1-20 v0.3.3 h1:17/glZSLI9P9fDAeyCHBFSWSqJcwx1byhLwP5eUIDCM=
++github.com/quic-go/qtls-go1-20 v0.3.3/go.mod h1:X9Nh97ZL80Z+bX/gUXMbipO6OxdiDi58b/fMC9mAL+k=
++github.com/quic-go/quic-go v0.38.1 h1:M36YWA5dEhEeT+slOu/SwMEucbYd0YFidxG3KlGPZaE=
++github.com/quic-go/quic-go v0.38.1/go.mod h1:ijnZM7JsFIkp4cRyjxJNIzdSfCLmUMg9wdyhGmg+SN4=
+ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+-github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
++github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+ github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=
+ github.com/spf13/afero v1.9.5/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
+-github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
+-github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155UU=
+-github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
+-github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
++github.com/spf13/cast v1.5.1 h1:R+kOtfhWQE6TVQzY+4D7wJLBgkdVasCEFxSUBYBYIlA=
++github.com/spf13/cast v1.5.1/go.mod h1:b9PdjNptOpzXr7Rq1q9gJML/2cdGQAo69NKzQ10KN48=
++github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
++github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
+ github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
+ github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
+ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+-github.com/spf13/viper v1.15.0 h1:js3yy885G8xwJa6iOISGFwd+qlUo5AvyXb7CiihdtiU=
+-github.com/spf13/viper v1.15.0/go.mod h1:fFcTBJxvhhzSJiZy8n+PeW6t8l+KeT/uTARa0jHOQLA=
++github.com/spf13/viper v1.16.0 h1:rGGH0XDZhdUOryiDWjmIvUSWpbNqisK8Wk0Vyefw8hc=
++github.com/spf13/viper v1.16.0/go.mod h1:yg78JgCJcbrQOvV9YLXgkLaZqUidkY9K+Dd1FofRzQg=
+ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+ github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
++github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+-github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
+-github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
++github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
++github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
++github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
++github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+ github.com/vishvananda/netlink v1.2.1-beta.2.0.20221107222636-d3c0a2caa559 h1:NwQroOyW+fpfiUroBzAMqFc6NRwBmvJevoVtEK6gsFE=
+ github.com/vishvananda/netlink v1.2.1-beta.2.0.20221107222636-d3c0a2caa559/go.mod h1:cAAsePK2e15YDAMJNyOpGYEWNe4sIghTY7gpz4cX/Ik=
+ github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
+@@ -247,15 +244,13 @@ go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
+ go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
+ go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
+ go.opencensus.io v0.22.5/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
+-go.uber.org/atomic v1.10.0 h1:9qC72Qh0+3MqyJbAn8YU5xVq1frD8bn3JtD2oXtafVQ=
+-go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
+-go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=
+-go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+-go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+-go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=
+-go.uber.org/zap v1.24.0/go.mod h1:2kMP+WWQ8aoFoedH3T2sq6iJ2yDWpHbP0f6MQbS9Gkg=
+-go4.org/netipx v0.0.0-20230303233057-f1b76eb4bb35 h1:nJAwRlGWZZDOD+6wni9KVUNHMpHko/OnRwsrCYeAzPo=
+-go4.org/netipx v0.0.0-20230303233057-f1b76eb4bb35/go.mod h1:TQvodOM+hJTioNQJilmLXu08JNb8i+ccq418+KWu1/Y=
++go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
++go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
++go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
++go.uber.org/zap v1.25.0 h1:4Hvk6GtkucQ790dqmj7l1eEnRdKm3k3ZUrUMS2d5+5c=
++go.uber.org/zap v1.25.0/go.mod h1:JIAUzQIH94IC4fOJQm7gMmBJP5k7wQfdcnYdPoEXJYk=
++go4.org/netipx v0.0.0-20230824141953-6213f710f925 h1:eeQDDVKFkx0g4Hyy8pHgmZaK0EqB4SD6rvKbUdN3ziQ=
++go4.org/netipx v0.0.0-20230824141953-6213f710f925/go.mod h1:PLyyIXexvUFg3Owu6p/WfdlivPbZJsZdgWZlrGope/Y=
+ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+@@ -263,8 +258,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
+ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+ golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+ golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+-golang.org/x/crypto v0.7.0 h1:AvwMYaRytfdeVt3u6mLaxYtErKYjxA2OXjJ1HHq6t3A=
+-golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=
++golang.org/x/crypto v0.12.0 h1:tFM/ta59kqch6LlvYnPa0yx5a83cL2nHflFhYKvv9Yk=
++golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98yw=
+ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+ golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+ golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
+@@ -275,8 +270,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
+ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
+ golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
+ golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+-golang.org/x/exp v0.0.0-20230314191032-db074128a8ec h1:pAv+d8BM2JNnNctsLJ6nnZ6NqXT8N4+eauvZSb3P0I0=
+-golang.org/x/exp v0.0.0-20230314191032-db074128a8ec/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
++golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63 h1:m64FZMko/V45gv0bNmrNYoDEq8U5YUhetc9cBWKS1TQ=
++golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63/go.mod h1:0v4NqG35kSWCMzLaMeX+IQrlSnVE/bqGSyC2cz/9Le8=
+ golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
+ golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+ golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
+@@ -301,8 +296,8 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+ golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+ golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+ golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+-golang.org/x/mod v0.9.0 h1:KENHtAZL2y3NLMYZeHY9DW8HW8V+kQyJsY/V9JlKvCs=
+-golang.org/x/mod v0.9.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
++golang.org/x/mod v0.12.0 h1:rmsUpXtvNzj340zd98LZ4KntptpfRHwpFOHG188oHXc=
++golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+ golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+ golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+ golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+@@ -336,8 +331,8 @@ golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v
+ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+ golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+-golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=
+-golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
++golang.org/x/net v0.14.0 h1:BONx9s002vGdD9umnlX1Po8vOZmrgH34qlHcD1MfK14=
++golang.org/x/net v0.14.0/go.mod h1:PpSgVXXLK0OxS0F31C1/tv6XNguvCrnXIDrFMspZIUI=
+ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+ golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+@@ -358,8 +353,8 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
+ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+-golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+-golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
++golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
++golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
+ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+ golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+@@ -401,8 +396,8 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
+ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220804214406-8e32c043e418/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
+-golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
++golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
++golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+@@ -412,8 +407,8 @@ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+-golang.org/x/text v0.8.0 h1:57P1ETyNKtuIjB4SRd15iJxuhj8Gc416Y78H3qgMh68=
+-golang.org/x/text v0.8.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
++golang.org/x/text v0.12.0 h1:k+n5B8goJNdU7hSvEtMUz3d1Q6D/XW4COJSJR6fN0mc=
++golang.org/x/text v0.12.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
+ golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+ golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+@@ -465,8 +460,8 @@ golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4f
+ golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+ golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
+ golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+-golang.org/x/tools v0.7.0 h1:W4OVu8VVOaIO0yzWMNdepAulS7YfoS3Zabrm8DOXXU4=
+-golang.org/x/tools v0.7.0/go.mod h1:4pg6aUX35JBAogB10C9AtvVL+qowtN4pT3CGSQex14s=
++golang.org/x/tools v0.12.1-0.20230815132531-74c255bcf846 h1:Vve/L0v7CXXuxUmaMGIEK/dEeq7uiqb5qBgQrZzIE7E=
++golang.org/x/tools v0.12.1-0.20230815132531-74c255bcf846/go.mod h1:Sc0INKfu04TlqNoRA1hgpFZbhYXHPr4V5DzpSBTPqQM=
+ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+@@ -561,8 +556,8 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
+ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
+ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+-google.golang.org/protobuf v1.29.1 h1:7QBf+IK2gx70Ap/hDsOmam3GE0v9HicjfEdAxE62UoM=
+-google.golang.org/protobuf v1.29.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
++google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
++google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+diff --git a/pkg/server/http_handler/handler.go b/pkg/server/http_handler/handler.go
+index 3e800f9..25f52e1 100644
+--- a/pkg/server/http_handler/handler.go
++++ b/pkg/server/http_handler/handler.go
+@@ -96,6 +96,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+ 	if err != nil {
+ 		h.warnErr(req, "invalid request", err)
+ 		w.WriteHeader(http.StatusBadRequest)
++		w.Write([]byte("Bad Request"))
+ 		return
+ 	}
+ 
+diff --git a/pkg/upstream/upstream.go b/pkg/upstream/upstream.go
+index d0fdc74..8486563 100644
+--- a/pkg/upstream/upstream.go
++++ b/pkg/upstream/upstream.go
+@@ -23,6 +23,14 @@ import (
+ 	"context"
+ 	"crypto/tls"
+ 	"fmt"
++	"io"
++	"net"
++	"net/http"
++	"net/url"
++	"strconv"
++	"strings"
++	"time"
++
+ 	"github.com/IrineSistiana/mosdns/v5/mlog"
+ 	"github.com/IrineSistiana/mosdns/v5/pkg/dnsutils"
+ 	"github.com/IrineSistiana/mosdns/v5/pkg/upstream/bootstrap"
+@@ -33,13 +41,6 @@ import (
+ 	"github.com/quic-go/quic-go/http3"
+ 	"go.uber.org/zap"
+ 	"golang.org/x/net/http2"
+-	"io"
+-	"net"
+-	"net/http"
+-	"net/url"
+-	"strconv"
+-	"strings"
+-	"time"
+ )
+ 
+ const (
+@@ -233,7 +234,10 @@ func NewUpstream(addr string, opt Opt) (Upstream, error) {
+ 			if err != nil {
+ 				return nil, fmt.Errorf("failed to init udp socket for quic")
+ 			}
+-			addonCloser = conn
++			qt := &quic.Transport{
++				Conn: conn,
++			}
++			addonCloser = qt
+ 			t = &http3.RoundTripper{
+ 				TLSClientConfig: opt.TLSConfig,
+ 				QuicConfig: &quic.Config{
+@@ -248,7 +252,8 @@ func NewUpstream(addr string, opt Opt) (Upstream, error) {
+ 					if err != nil {
+ 						return nil, err
+ 					}
+-					return quic.DialEarlyContext(ctx, conn, ua, addrURL.Host, tlsCfg, cfg)
++
++					return qt.DialEarly(ctx, ua, tlsCfg, cfg)
+ 				},
+ 			}
+ 		} else {
+-- 
+2.34.8
+

--- a/net/mosdns/patches/101-fix-nftset-mask.patch
+++ b/net/mosdns/patches/101-fix-nftset-mask.patch
@@ -1,0 +1,57 @@
+From 0cb2257a6cbb63e0717f2324bb7563c32714934f Mon Sep 17 00:00:00 2001
+From: Irine Sistiana <49315432+IrineSistiana@users.noreply.github.com>
+Date: Fri, 16 Jun 2023 14:56:30 +0800
+Subject: [PATCH] fix #667
+
+---
+ pkg/nftset_utils/handler.go | 27 +++++++++++++++------------
+ 1 file changed, 15 insertions(+), 12 deletions(-)
+
+diff --git a/pkg/nftset_utils/handler.go b/pkg/nftset_utils/handler.go
+index 7403f390a..3b79afb42 100644
+--- a/pkg/nftset_utils/handler.go
++++ b/pkg/nftset_utils/handler.go
+@@ -24,11 +24,12 @@ package nftset_utils
+ import (
+ 	"errors"
+ 	"fmt"
+-	"github.com/google/nftables"
+-	"go4.org/netipx"
+ 	"net/netip"
+ 	"sync"
+ 	"time"
++
++	"github.com/google/nftables"
++	"go4.org/netipx"
+ )
+ 
+ var (
+@@ -113,16 +114,18 @@ func (h *NftSetHandler) AddElems(es ...netip.Prefix) error {
+ 		elems = make([]nftables.SetElement, 0, len(es))
+ 	}
+ 
+-	for _, e := range es {
+-		if set.Interval && !e.IsSingleIP() {
+-			r := netipx.RangeOfPrefix(e)
+-			start := r.From()
+-			end := r.To()
+-			elems = append(
+-				elems,
+-				nftables.SetElement{Key: start.AsSlice(), IntervalEnd: false},
+-				nftables.SetElement{Key: end.Next().AsSlice(), IntervalEnd: true},
+-			)
++	for i, e := range es {
++		if !e.IsValid() {
++			return fmt.Errorf("invalid prefix at index %d", i)
++		}
++		if set.Interval {
++			start := e.Masked().Addr()
++			elems = append(elems, nftables.SetElement{Key: start.AsSlice(), IntervalEnd: false})
++			
++			end := netipx.PrefixLastIP(e).Next() // may be invalid if end is overflowed
++			if end.IsValid() {
++				elems = append(elems, nftables.SetElement{Key: end.AsSlice(), IntervalEnd: true})
++			}
+ 		} else {
+ 			elems = append(elems, nftables.SetElement{Key: e.Addr().AsSlice()})
+ 		}

--- a/net/mosdns/patches/200-add-debug-log-again.patch
+++ b/net/mosdns/patches/200-add-debug-log-again.patch
@@ -1,0 +1,43 @@
+From 90530ab71c101e8aa620a8d7669ffd7f59dfebf4 Mon Sep 17 00:00:00 2001
+From: sbwml <admin@cooluc.com>
+Date: Sun, 25 Jun 2023 06:50:27 +0800
+Subject: [PATCH] add debug log again
+
+---
+ pkg/server/dns_handler/entry_handler.go | 4 +++-
+ plugin/executable/cache/cache.go        | 3 +++
+ 2 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/pkg/server/dns_handler/entry_handler.go b/pkg/server/dns_handler/entry_handler.go
+index 4737811..cec4123 100644
+--- a/pkg/server/dns_handler/entry_handler.go
++++ b/pkg/server/dns_handler/entry_handler.go
+@@ -90,7 +90,9 @@ func (h *EntryHandler) ServeDNS(ctx context.Context, qCtx *query_context.Context
+ 	err := h.opts.Entry.Exec(ctx, qCtx)
+ 	respMsg := qCtx.R()
+ 	if err != nil {
+-		h.opts.Logger.Warn("entry err", qCtx.InfoField(), zap.Error(err))
++		h.opts.Logger.Warn("entry returned an err", qCtx.InfoField(), zap.Error(err))
++	} else {
++		h.opts.Logger.Debug("entry returned", qCtx.InfoField())
+ 	}
+ 
+ 	if err == nil && respMsg == nil {
+diff --git a/plugin/executable/cache/cache.go b/plugin/executable/cache/cache.go
+index f67d740..c590a01 100644
+--- a/plugin/executable/cache/cache.go
++++ b/plugin/executable/cache/cache.go
+@@ -203,7 +203,10 @@ func (c *Cache) Exec(ctx context.Context, qCtx *query_context.Context, next sequ
+ 		c.hitTotal.Inc()
+ 		cachedResp.Id = q.Id // change msg id
+ 		shuffleIP(cachedResp)
++		c.logger.Debug("cache hit", qCtx.InfoField())
+ 		qCtx.SetResponse(cachedResp)
++	} else {
++		c.logger.Debug("cache miss", qCtx.InfoField())
+ 	}
+ 
+ 	err := next.ExecNext(ctx, qCtx)
+-- 
+2.34.8
+


### PR DESCRIPTION
Maintainer: Tianling Shen <cnsztl@immortalwrt.org>
Compile tested: 

```
 evine@opbuilder  ~/lede   master  make package/feeds/packages/mosdns/{clean,compile} V=s 
Collecting package info: done
make[2]: Entering directory '/home/evine/lede/scripts/config'
make[2]: 'conf' is up to date.
make[2]: Leaving directory '/home/evine/lede/scripts/config'
make[1]: Entering directory '/home/evine/lede'
make[2]: Entering directory '/home/evine/lede/feeds/packages/net/mosdns'
rm -rf /home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3
/home/evine/lede/scripts/ipkg-remove mosdns /home/evine/lede/bin/packages/x86_64/packages/mosdns_5.1.3-1_x86_64.ipk
removed '/home/evine/lede/bin/packages/x86_64/packages/mosdns_5.1.3-1_x86_64.ipk'
rm -f /home/evine/lede/staging_dir/target-x86_64_musl/stamp/.mosdns_installed
rm -f /home/evine/lede/staging_dir/target-x86_64_musl/packages/mosdns.list
make[2]: Leaving directory '/home/evine/lede/feeds/packages/net/mosdns'
time: package/feeds/packages/mosdns/clean#0.20#0.07#0.30
make[1]: Leaving directory '/home/evine/lede'
make[2]: Entering directory '/home/evine/lede/scripts/config'
make[2]: 'conf' is up to date.
make[2]: Leaving directory '/home/evine/lede/scripts/config'
make[1]: Entering directory '/home/evine/lede'
make[2]: Entering directory '/home/evine/lede/feeds/packages/lang/golang/golang'
make[2]: Leaving directory '/home/evine/lede/feeds/packages/lang/golang/golang'
time: package/feeds/packages/golang/host-compile#0.32#0.26#0.61
make[2]: Entering directory '/home/evine/lede/package/libs/toolchain'
echo "libc" >> /home/evine/lede/staging_dir/target-x86_64_musl/pkginfo/toolchain.default.install
echo "libgcc" >> /home/evine/lede/staging_dir/target-x86_64_musl/pkginfo/toolchain.default.install
echo "libatomic" >> /home/evine/lede/staging_dir/target-x86_64_musl/pkginfo/toolchain.default.install
echo "libstdcpp" >> /home/evine/lede/staging_dir/target-x86_64_musl/pkginfo/toolchain.default.install
echo "libpthread" >> /home/evine/lede/staging_dir/target-x86_64_musl/pkginfo/toolchain.default.install
echo "librt" >> /home/evine/lede/staging_dir/target-x86_64_musl/pkginfo/toolchain.default.install
make[2]: Leaving directory '/home/evine/lede/package/libs/toolchain'
time: package/libs/toolchain/compile#0.10#0.02#0.14
make[2]: Entering directory '/home/evine/lede/package/system/ca-certificates'
echo "ca-bundle" >> /home/evine/lede/staging_dir/target-x86_64_musl/pkginfo/ca-certificates.default.install
echo "ca-certificates" >> /home/evine/lede/staging_dir/target-x86_64_musl/pkginfo/ca-certificates.default.install
make[2]: Leaving directory '/home/evine/lede/package/system/ca-certificates'
time: package/system/ca-certificates/compile#0.10#0.01#0.12
make[2]: Entering directory '/home/evine/lede/feeds/packages/net/mosdns'
touch /home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.prepared_3d217bf5236cc314a7ee1334f9882a5f_6664517399ebbbc92a37c5bb081b5c53_check
. /home/evine/lede/include/shell.sh; /home/evine/lede/staging_dir/host/bin/libdeflate-gzip -dc /home/evine/lede/dl/mosdns-5.1.3.tar.gz | tar -C /home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.. -xf -
[ ! -d ./src/ ] || cp -fpR ./src/. /home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3

Applying ./patches/100-update-deps.patch using plaintext: 
patching file go.mod
patching file go.sum
patching file pkg/server/http_handler/handler.go
patching file pkg/upstream/upstream.go

Applying ./patches/101-fix-nftset-mask.patch using plaintext: 
patching file pkg/nftset_utils/handler.go

Applying ./patches/200-add-debug-log-again.patch using plaintext: 
patching file pkg/server/dns_handler/entry_handler.go
patching file plugin/executable/cache/cache.go
touch /home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.prepared_3d217bf5236cc314a7ee1334f9882a5f_6664517399ebbbc92a37c5bb081b5c53
rm -f /home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.configured_*
rm -f /home/evine/lede/staging_dir/target-x86_64_musl/stamp/.mosdns_installed
CONFIG_GOLANG_MOD_CACHE_WORLD_READABLE="" GO_BUILD_CACHE_DIR="/home/evine/lede/tmp/go-build" GO_MOD_CACHE_DIR="/home/evine/lede/dl/go-mod-cache" GO_MOD_ARGS="-modcacherw" GO_PKG="github.com/IrineSistiana/mosdns" GO_INSTALL_EXTRA="" GO_INSTALL_ALL="" GO_SOURCE_ONLY="" GO_BUILD_PKG="github.com/IrineSistiana/mosdns/..." GO_EXCLUDES="" GO_GO_GENERATE="" GO_INSTALL_BIN_PATH="/usr/bin" BUILD_DIR="/home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3" GO_BUILD_DIR="/home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.go_work/build" GO_BUILD_BIN_DIR="/home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.go_work/build/bin" GO_BUILD_DEPENDS_PATH="/usr/share/gocode" GO_BUILD_DEPENDS_SRC="/home/evine/lede/staging_dir/target-x86_64_musl/usr/share/gocode/src" /usr/bin/env bash ../../lang/golang//golang-build.sh configure
Copying files from /home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3 into /home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.go_work/build/src/github.com/IrineSistiana/mosdns
coremain/config.go
coremain/mosdns.go
coremain/plugin.go
coremain/run.go
coremain/service.go
go.mod
go.sum
main.go
mlog/logger.go
pkg/cache/cache.go
pkg/cache/cache_test.go
pkg/concurrent_lru/concurrent_lru.go
pkg/concurrent_lru/concurrent_lru_test.go
pkg/concurrent_map/map.go
pkg/concurrent_map/map_test.go
pkg/dnsutils/edns0.go
pkg/dnsutils/edns0_ecs.go
pkg/dnsutils/edns0_padding.go
pkg/dnsutils/edns0_padding_test.go
pkg/dnsutils/msg.go
pkg/dnsutils/net_io.go
pkg/dnsutils/ptr_parser.go
pkg/dnsutils/ptr_parser_test.go
pkg/hosts/hosts.go
pkg/hosts/hosts_test.go
pkg/list/elem.go
pkg/list/list.go
pkg/list/list_test.go
pkg/lru/lru.go
pkg/lru/lru_test.go
pkg/matcher/domain/interface.go
pkg/matcher/domain/load_helper.go
pkg/matcher/domain/matcher.go
pkg/matcher/domain/matcher_test.go
pkg/matcher/domain/utils.go
pkg/matcher/domain/utils_test.go
pkg/matcher/netlist/interface.go
pkg/matcher/netlist/list.go
pkg/matcher/netlist/load_helper.go
pkg/matcher/netlist/netlist_test.go
pkg/nftset_utils/handler.go
pkg/nftset_utils/handler_test.go
pkg/pool/allocator.go
pkg/pool/allocator_test.go
pkg/pool/bytes_buf.go
pkg/pool/msg_buf.go
pkg/pool/msg_buf_test.go
pkg/pool/timer.go
pkg/query_context/client_addr.go
pkg/query_context/context.go
pkg/query_context/kv.go
pkg/safe_close/safe_close.go
pkg/server/dns_handler/entry_handler.go
pkg/server/http_handler/handler.go
pkg/server/tcp.go
pkg/server/tls.go
pkg/server/udp.go
pkg/server/udp_linux.go
pkg/server/udp_others.go
pkg/upstream/bootstrap/bootstrap.go
pkg/upstream/bootstrap/bootstrap_test.go
pkg/upstream/doh/upstream.go
pkg/upstream/event_stat.go
pkg/upstream/transport/dns_conn.go
pkg/upstream/transport/dns_conn_test.go
pkg/upstream/transport/pipeline.go
pkg/upstream/transport/pipeline_test.go
pkg/upstream/transport/reuse.go
pkg/upstream/transport/reuse_test.go
pkg/upstream/transport/transport.go
pkg/upstream/transport/utils.go
pkg/upstream/transport/utils_test.go
pkg/upstream/upstream.go
pkg/upstream/upstream_test.go
pkg/upstream/utils.go
pkg/upstream/utils_others.go
pkg/upstream/utils_unix.go
pkg/utils/config_helper.go
pkg/utils/errors.go
pkg/utils/net.go
pkg/utils/server.go
pkg/utils/strings.go
pkg/utils/utils.go
pkg/utils/utils_test.go
pkg/zone_file/zone_file.go
pkg/zone_file/zone_file_test.go
plugin/data_provider/domain_set/domain_set.go
plugin/data_provider/domain_set/group.go
plugin/data_provider/iface.go
plugin/data_provider/ip_set/ip_set.go
plugin/enabled_plugin_test.go
plugin/enabled_plugins.go
plugin/executable/arbitrary/arbitrary.go
plugin/executable/black_hole/black_hole.go
plugin/executable/cache/cache.go
plugin/executable/cache/cache_test.go
plugin/executable/cache/dump.pb.go
plugin/executable/cache/dump.proto
plugin/executable/cache/utils.go
plugin/executable/debug_print/print.go
plugin/executable/drop_resp/drop_resp.go
plugin/executable/dual_selector/dual_selector.go
plugin/executable/dual_selector/dual_selector_test.go
plugin/executable/ecs/ecs.go
plugin/executable/forward/forward.go
plugin/executable/forward/utils.go
plugin/executable/hosts/hosts.go
plugin/executable/ipset/ipset.go
plugin/executable/ipset/ipset_linux.go
plugin/executable/ipset/ipset_other.go
plugin/executable/ipset/ipset_test.go
plugin/executable/metrics_collector/collector.go
plugin/executable/nftset/nftset.go
plugin/executable/nftset/nftset_linux.go
plugin/executable/nftset/nftset_other.go
plugin/executable/query_summary/query_summary.go
plugin/executable/redirect/redirect.go
plugin/executable/reverse_lookup/reverse_lookup.go
plugin/executable/reverse_lookup/utils.go
plugin/executable/sequence/built_in.go
plugin/executable/sequence/chain.go
plugin/executable/sequence/config.go
plugin/executable/sequence/config_test.go
plugin/executable/sequence/fallback/fallback.go
plugin/executable/sequence/iface.go
plugin/executable/sequence/quick_config.go
plugin/executable/sequence/quick_setup.go
plugin/executable/sequence/sequence.go
plugin/executable/sequence/sequence_test.go
plugin/executable/sequence/utils.go
plugin/executable/sleep/sleep.go
plugin/executable/ttl/ttl.go
plugin/mark/mark.go
plugin/matcher/base_domain/domain_matcher.go
plugin/matcher/base_int/int_matcher.go
plugin/matcher/base_ip/ip_matcher.go
plugin/matcher/client_ip/client_ip_matcher.go
plugin/matcher/cname/cname_matcher.go
plugin/matcher/env/env.go
plugin/matcher/has_resp/has_resp.go
plugin/matcher/has_wanted_ans/has_wanted_ans.go
plugin/matcher/ptr_ip/ptr_ip.go
plugin/matcher/qclass/qclass.go
plugin/matcher/qname/qname.go
plugin/matcher/qtype/qtype.go
plugin/matcher/random/random.go
plugin/matcher/rcode/rcode.go
plugin/matcher/resp_ip/resp_ip.go
plugin/server/http_server/http_server.go
plugin/server/server_utils/handler.go
plugin/server/tcp_server/tcp_server.go
plugin/server/udp_server/udp_server.go
tools/config.go
tools/init.go
tools/probe.go

Symlinking directories from /home/evine/lede/staging_dir/target-x86_64_musl/usr/share/gocode/src into /home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.go_work/build/src
.../github.com/urlesistiana
.../github.com/cnsilvan
.../github.com/xtls
.../github.com/AdguardTeam
.../github.com/v2fly

touch /home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.configured_1cd727ac7b9ebbe4ee453b5ddb8504b3
rm -f /home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.built
touch /home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.built_check
CONFIG_GOLANG_MOD_CACHE_WORLD_READABLE="" GO_BUILD_CACHE_DIR="/home/evine/lede/tmp/go-build" GO_MOD_CACHE_DIR="/home/evine/lede/dl/go-mod-cache" GO_MOD_ARGS="-modcacherw" GO_PKG="github.com/IrineSistiana/mosdns" GO_INSTALL_EXTRA="" GO_INSTALL_ALL="" GO_SOURCE_ONLY="" GO_BUILD_PKG="github.com/IrineSistiana/mosdns/..." GO_EXCLUDES="" GO_GO_GENERATE="" GO_INSTALL_BIN_PATH="/usr/bin" BUILD_DIR="/home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3" GO_BUILD_DIR="/home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.go_work/build" GO_BUILD_BIN_DIR="/home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.go_work/build/bin" GO_BUILD_DEPENDS_PATH="/usr/share/gocode" GO_BUILD_DEPENDS_SRC="/home/evine/lede/staging_dir/target-x86_64_musl/usr/share/gocode/src" GOOS="linux" GOARCH="amd64" GO386="" GOAMD64="v1" GOARM="" GOMIPS="" GOMIPS64="" GOPPC64="" CC="x86_64-openwrt-linux-musl-gcc" CXX="x86_64-openwrt-linux-musl-g++" CGO_CFLAGS="-Os -pipe -fno-caller-saves -fno-plt -fhonour-copts -fmacro-prefix-map=/home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3=mosdns-5.1.3 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro" CGO_CPPFLAGS="-I/home/evine/lede/staging_dir/toolchain-x86_64_gcc-11.3.0_musl/usr/include -I/home/evine/lede/staging_dir/toolchain-x86_64_gcc-11.3.0_musl/include/fortify -I/home/evine/lede/staging_dir/toolchain-x86_64_gcc-11.3.0_musl/include" CGO_CXXFLAGS="-Os -pipe -fno-caller-saves -fno-plt -fhonour-copts -fmacro-prefix-map=/home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3=mosdns-5.1.3 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro" CGO_LDFLAGS="-L/home/evine/lede/staging_dir/toolchain-x86_64_gcc-11.3.0_musl/usr/lib -L/home/evine/lede/staging_dir/toolchain-x86_64_gcc-11.3.0_musl/lib -znow -zrelro" CGO_ENABLED=0 GOPATH="/home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.go_work/build" GOCACHE="/home/evine/lede/tmp/go-build" GOMODCACHE="/home/evine/lede/dl/go-mod-cache" GOENV=off /usr/bin/env bash ../../lang/golang//golang-build.sh build -v -buildvcs=false -trimpath -ldflags "all=-buildid '1693135822' -linkmode external -extldflags '-L/home/evine/lede/staging_dir/toolchain-x86_64_gcc-11.3.0_musl/usr/lib -L/home/evine/lede/staging_dir/toolchain-x86_64_gcc-11.3.0_musl/lib -Wl,-z,now -Wl,-z,relro'"        -ldflags " -X main.version=v5.1.3 -buildid '1693135822' -linkmode external -extldflags '-L/home/evine/lede/staging_dir/toolchain-x86_64_gcc-11.3.0_musl/usr/lib -L/home/evine/lede/staging_dir/toolchain-x86_64_gcc-11.3.0_musl/lib -Wl,-z,now -Wl,-z,relro'"  
Finding targets
go: downloading github.com/miekg/dns v1.1.55
go: downloading go.uber.org/zap v1.25.0
go: downloading github.com/go-chi/chi/v5 v5.0.10
go: downloading github.com/prometheus/client_golang v1.16.0
go: downloading golang.org/x/net v0.14.0
go: downloading github.com/spf13/cobra v1.7.0
go: downloading go4.org/netipx v0.0.0-20230824141953-6213f710f925
go: downloading github.com/spf13/viper v1.16.0
go: downloading golang.org/x/sys v0.11.0
go: downloading github.com/quic-go/quic-go v0.38.1
go: downloading github.com/klauspost/compress v1.16.7
go: downloading golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63
go: downloading golang.org/x/sync v0.3.0
go: downloading google.golang.org/protobuf v1.31.0
go: downloading github.com/mdlayher/netlink v1.7.2
go: downloading go.uber.org/multierr v1.11.0
go: downloading github.com/prometheus/client_model v0.4.0
go: downloading github.com/prometheus/common v0.44.0
go: downloading github.com/prometheus/procfs v0.11.1
go: downloading github.com/spf13/cast v1.5.1
go: downloading github.com/mdlayher/socket v0.4.1
go: downloading golang.org/x/text v0.12.0
go: downloading github.com/subosito/gotenv v1.6.0
go: downloading github.com/pelletier/go-toml/v2 v2.0.9
go: downloading golang.org/x/crypto v0.12.0
go: downloading github.com/quic-go/qtls-go1-20 v0.3.3

Building targets
encoding
internal/race
internal/itoa
internal/goarch
unicode/utf8
internal/goos
internal/coverage/rtcov
unicode/utf16
internal/unsafeheader
math/bits
internal/goexperiment
unicode
internal/cpu
runtime/internal/syscall
sync/atomic
runtime/internal/atomic
container/list
crypto/internal/alias
crypto/subtle
crypto/internal/boring/sig
vendor/golang.org/x/crypto/cryptobyte/asn1
internal/nettrace
vendor/golang.org/x/crypto/internal/alias
internal/abi
runtime/internal/math
runtime/internal/sys
golang.org/x/exp/constraints
google.golang.org/protobuf/internal/flags
google.golang.org/protobuf/internal/set
golang.org/x/text/internal/utf8internal
golang.org/x/text/encoding/internal/identifier
golang.org/x/net/internal/iana
github.com/pelletier/go-toml/v2/internal/characters
github.com/IrineSistiana/mosdns/v5/pkg/list
hash/maphash
golang.org/x/crypto/internal/alias
golang.org/x/crypto/cryptobyte/asn1
github.com/quic-go/quic-go/internal/utils/ringbuffer
internal/bytealg
math
runtime
runtime/metrics
internal/reflectlite
sync
github.com/IrineSistiana/mosdns/v5/pkg/safe_close
internal/singleflight
go.uber.org/zap/internal/pool
google.golang.org/protobuf/internal/pragma
internal/godebug
github.com/IrineSistiana/mosdns/v5/pkg/concurrent_map
internal/testlog
github.com/quic-go/quic-go/internal/utils/linkedlist
github.com/spf13/viper/internal/encoding
internal/intern
math/rand
errors
sort
internal/oserror
path
internal/safefilepath
io
github.com/hashicorp/hcl/hcl/strconv
vendor/golang.org/x/net/dns/dnsmessage
strconv
crypto/internal/nistec/fiat
syscall
github.com/beorn7/perks/quantile
hash
crypto/internal/randutil
text/tabwriter
bytes
strings
hash/fnv
hash/crc32
golang.org/x/text/transform
vendor/golang.org/x/text/transform
net/http/internal/ascii
bufio
html
crypto/rc4
crypto
github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
encoding/base32
net/netip
reflect
regexp/syntax
golang.org/x/text/runes
golang.org/x/text/encoding
golang.org/x/text/encoding/internal
golang.org/x/text/encoding/unicode
internal/syscall/execenv
internal/syscall/unix
time
regexp
go.uber.org/zap/buffer
io/fs
context
internal/poll
go.uber.org/zap/internal/bufferpool
github.com/spf13/afero/internal/common
embed
os
internal/fmtsort
encoding/binary
github.com/nadoo/ipset/internal/netlink
github.com/cespare/xxhash/v2
crypto/md5
github.com/google/nftables/binaryutil
github.com/josharian/native
vendor/golang.org/x/crypto/internal/poly1305
golang.org/x/crypto/internal/poly1305
crypto/cipher
encoding/base64
crypto/internal/edwards25519/field
crypto/sha1
crypto/internal/nistec
golang.org/x/sys/unix
encoding/pem
go.uber.org/zap/internal/exit
io/ioutil
path/filepath
net
fmt
os/signal
google.golang.org/protobuf/internal/detrand
github.com/prometheus/procfs/internal/util
github.com/nadoo/ipset
crypto/des
crypto/internal/boring
crypto/internal/edwards25519
vendor/golang.org/x/crypto/chacha20
vendor/golang.org/x/sys/cpu
golang.org/x/crypto/chacha20
golang.org/x/sys/cpu
crypto/hmac
crypto/sha512
crypto/aes
crypto/sha256
vendor/golang.org/x/crypto/hkdf
golang.org/x/crypto/hkdf
github.com/spf13/afero/mem
os/exec
vendor/golang.org/x/crypto/chacha20poly1305
golang.org/x/crypto/chacha20poly1305
crypto/ecdh
go.uber.org/zap/internal/color
log
go.uber.org/multierr
encoding/hex
vendor/golang.org/x/net/http2/hpack
mime
net/http/internal
mime/quotedprintable
net/url
flag
encoding/json
compress/flate
math/big
vendor/golang.org/x/text/unicode/norm
text/template/parse
google.golang.org/protobuf/internal/errors
go/token
google.golang.org/protobuf/internal/version
github.com/prometheus/procfs/internal/fs
vendor/golang.org/x/text/unicode/bidi
runtime/debug
database/sql/driver
google.golang.org/protobuf/encoding/protowire
encoding/csv
golang.org/x/text/unicode/norm
github.com/spf13/jwalterweatherman
github.com/subosito/gotenv
google.golang.org/protobuf/reflect/protoreflect
github.com/hashicorp/hcl/hcl/token
database/sql
gopkg.in/ini.v1
github.com/pelletier/go-toml/v2/internal/danger
github.com/hashicorp/hcl/hcl/ast
github.com/hashicorp/hcl/hcl/scanner
github.com/hashicorp/hcl/json/token
github.com/pelletier/go-toml/v2/unstable
compress/gzip
gopkg.in/yaml.v3
vendor/golang.org/x/text/secure/bidirule
github.com/hashicorp/hcl/json/scanner
github.com/hashicorp/hcl/hcl/parser
internal/profile
github.com/hashicorp/hcl/json/parser
runtime/pprof
google.golang.org/protobuf/internal/descfmt
text/template
google.golang.org/protobuf/internal/descopts
google.golang.org/protobuf/internal/strs
google.golang.org/protobuf/internal/encoding/messageset
google.golang.org/protobuf/internal/genid
google.golang.org/protobuf/internal/encoding/text
vendor/golang.org/x/net/idna
google.golang.org/protobuf/internal/order
google.golang.org/protobuf/runtime/protoiface
go.uber.org/zap/zapcore
google.golang.org/protobuf/reflect/protoregistry
github.com/prometheus/common/model
github.com/hashicorp/hcl
github.com/fsnotify/fsnotify
github.com/hashicorp/hcl/hcl/printer
github.com/spf13/viper/internal/encoding/json
github.com/pelletier/go-toml/v2/internal/tracker
runtime/trace
golang.org/x/net/bpf
google.golang.org/protobuf/internal/encoding/defval
crypto/rand
crypto/elliptic
crypto/internal/boring/bbig
crypto/internal/bigmod
encoding/asn1
crypto/dsa
google.golang.org/protobuf/proto
github.com/spf13/viper/internal/encoding/hcl
github.com/pelletier/go-toml/v2
github.com/IrineSistiana/mosdns/v5/pkg/lru
github.com/klauspost/compress/flate
crypto/ed25519
golang.org/x/sync/singleflight
github.com/quic-go/quic-go/internal/protocol
golang.org/x/net/http2/hpack
github.com/IrineSistiana/mosdns/v5/pkg/concurrent_lru
golang.org/x/text/unicode/bidi
github.com/mdlayher/netlink/nlenc
vendor/golang.org/x/net/http/httpproxy
crypto/rsa
log/syslog
net/textproto
github.com/mitchellh/mapstructure
github.com/prometheus/procfs
github.com/spf13/pflag
html/template
github.com/kardianos/service
golang.org/x/net/internal/socket
github.com/quic-go/quic-go/internal/utils
github.com/spf13/viper/internal/encoding/yaml
vendor/golang.org/x/crypto/cryptobyte
go.uber.org/zap/internal
crypto/x509/pkix
vendor/golang.org/x/net/http/httpguts
mime/multipart
google.golang.org/protobuf/internal/filedesc
google.golang.org/protobuf/encoding/prototext
golang.org/x/crypto/cryptobyte
github.com/quic-go/quic-go/quicvarint
github.com/quic-go/qpack
golang.org/x/text/secure/bidirule
golang.org/x/net/internal/socks
golang.org/x/sync/errgroup
golang.org/x/net/ipv4
crypto/ecdsa
golang.org/x/net/ipv6
github.com/mdlayher/socket
github.com/spf13/viper/internal/encoding/toml
golang.org/x/net/idna
github.com/google/nftables/alignedbuff
go4.org/netipx
golang.org/x/net/proxy
github.com/google/nftables/xt
github.com/spf13/cast
github.com/klauspost/compress/gzip
crypto/x509
github.com/mdlayher/netlink
google.golang.org/protobuf/internal/encoding/tag
github.com/spf13/cobra
github.com/spf13/viper/internal/encoding/ini
github.com/spf13/viper/internal/encoding/dotenv
google.golang.org/protobuf/internal/impl
golang.org/x/net/http/httpguts
github.com/google/nftables/internal/parseexprfunc
github.com/mdlayher/netlink/nltest
github.com/google/nftables/expr
crypto/tls
github.com/google/nftables
github.com/IrineSistiana/mosdns/v5/pkg/nftset_utils
net/http/httptrace
github.com/IrineSistiana/mosdns/v5/pkg/utils
github.com/quic-go/qtls-go1-20
github.com/miekg/dns
net/http
github.com/IrineSistiana/mosdns/v5/pkg/cache
github.com/IrineSistiana/mosdns/v5/pkg/matcher/netlist
github.com/IrineSistiana/mosdns/v5/pkg/matcher/domain
google.golang.org/protobuf/internal/filetype
google.golang.org/protobuf/runtime/protoimpl
github.com/IrineSistiana/mosdns/v5/plugin/data_provider
google.golang.org/protobuf/types/known/timestamppb
google.golang.org/protobuf/types/descriptorpb
github.com/prometheus/client_model/go
github.com/prometheus/client_golang/prometheus/internal
google.golang.org/protobuf/reflect/protodesc
github.com/golang/protobuf/proto
github.com/quic-go/quic-go/internal/qtls
github.com/quic-go/quic-go/internal/qerr
github.com/quic-go/quic-go/internal/flowcontrol
github.com/quic-go/quic-go/internal/wire
github.com/matttproud/golang_protobuf_extensions/pbutil
github.com/quic-go/quic-go/logging
github.com/quic-go/quic-go/internal/logutils
github.com/quic-go/quic-go/internal/congestion
github.com/quic-go/quic-go/internal/handshake
github.com/quic-go/quic-go/internal/ackhandler
github.com/quic-go/quic-go
github.com/IrineSistiana/mosdns/v5/pkg/zone_file
github.com/IrineSistiana/mosdns/v5/pkg/pool
github.com/IrineSistiana/mosdns/v5/pkg/upstream/transport
github.com/IrineSistiana/mosdns/v5/pkg/dnsutils
github.com/IrineSistiana/mosdns/v5/pkg/upstream/bootstrap
github.com/IrineSistiana/mosdns/v5/pkg/hosts
expvar
github.com/IrineSistiana/mosdns/v5/pkg/upstream/doh
net/http/pprof
github.com/go-chi/chi/v5
github.com/prometheus/common/expfmt
go.uber.org/zap
github.com/spf13/afero
golang.org/x/net/http2
github.com/magiconair/properties
github.com/spf13/viper/internal/encoding/javaproperties
github.com/prometheus/client_golang/prometheus
github.com/spf13/viper
github.com/IrineSistiana/mosdns/v5/mlog
github.com/IrineSistiana/mosdns/v5/pkg/query_context
github.com/quic-go/quic-go/http3
github.com/prometheus/client_golang/prometheus/collectors
github.com/prometheus/client_golang/prometheus/promhttp
github.com/IrineSistiana/mosdns/v5/pkg/upstream
github.com/IrineSistiana/mosdns/v5/coremain
github.com/IrineSistiana/mosdns/v5/plugin/data_provider/domain_set
github.com/IrineSistiana/mosdns/v5/plugin/data_provider/ip_set
github.com/IrineSistiana/mosdns/v5/tools
github.com/IrineSistiana/mosdns/v5/plugin/executable/sequence
github.com/IrineSistiana/mosdns/v5/plugin/executable/arbitrary
github.com/IrineSistiana/mosdns/v5/plugin/executable/black_hole
github.com/IrineSistiana/mosdns/v5/plugin/executable/debug_print
github.com/IrineSistiana/mosdns/v5/plugin/executable/drop_resp
github.com/IrineSistiana/mosdns/v5/plugin/executable/ecs
github.com/IrineSistiana/mosdns/v5/plugin/executable/dual_selector
github.com/IrineSistiana/mosdns/v5/plugin/executable/forward
github.com/IrineSistiana/mosdns/v5/plugin/executable/cache
github.com/IrineSistiana/mosdns/v5/plugin/executable/hosts
github.com/IrineSistiana/mosdns/v5/plugin/executable/ipset
github.com/IrineSistiana/mosdns/v5/plugin/executable/metrics_collector
github.com/IrineSistiana/mosdns/v5/plugin/executable/nftset
github.com/IrineSistiana/mosdns/v5/plugin/executable/redirect
github.com/IrineSistiana/mosdns/v5/plugin/executable/reverse_lookup
github.com/IrineSistiana/mosdns/v5/plugin/executable/query_summary
github.com/IrineSistiana/mosdns/v5/plugin/executable/sequence/fallback
github.com/IrineSistiana/mosdns/v5/plugin/executable/sleep
github.com/IrineSistiana/mosdns/v5/plugin/executable/ttl
github.com/IrineSistiana/mosdns/v5/plugin/mark
github.com/IrineSistiana/mosdns/v5/plugin/matcher/base_ip
github.com/IrineSistiana/mosdns/v5/plugin/matcher/base_domain
github.com/IrineSistiana/mosdns/v5/plugin/matcher/env
github.com/IrineSistiana/mosdns/v5/plugin/matcher/has_resp
github.com/IrineSistiana/mosdns/v5/plugin/matcher/has_wanted_ans
github.com/IrineSistiana/mosdns/v5/plugin/matcher/base_int
github.com/IrineSistiana/mosdns/v5/plugin/matcher/random
github.com/IrineSistiana/mosdns/v5/pkg/server/dns_handler
github.com/IrineSistiana/mosdns/v5/plugin/matcher/qclass
github.com/IrineSistiana/mosdns/v5/plugin/matcher/qtype
github.com/IrineSistiana/mosdns/v5/plugin/matcher/rcode
github.com/IrineSistiana/mosdns/v5/plugin/matcher/client_ip
github.com/IrineSistiana/mosdns/v5/plugin/matcher/resp_ip
github.com/IrineSistiana/mosdns/v5/plugin/matcher/ptr_ip
github.com/IrineSistiana/mosdns/v5/pkg/server/http_handler
github.com/IrineSistiana/mosdns/v5/plugin/server/server_utils
github.com/IrineSistiana/mosdns/v5/pkg/server
github.com/IrineSistiana/mosdns/v5/plugin/matcher/qname
github.com/IrineSistiana/mosdns/v5/plugin/matcher/cname
github.com/IrineSistiana/mosdns/v5/plugin/server/http_server
github.com/IrineSistiana/mosdns/v5/plugin/server/tcp_server
github.com/IrineSistiana/mosdns/v5/plugin/server/udp_server
github.com/IrineSistiana/mosdns/v5/plugin
github.com/IrineSistiana/mosdns/v5
# github.com/IrineSistiana/mosdns/v5
loadinternal: cannot find runtime/cgo

CONFIG_GOLANG_MOD_CACHE_WORLD_READABLE="" GO_BUILD_CACHE_DIR="/home/evine/lede/tmp/go-build" GO_MOD_CACHE_DIR="/home/evine/lede/dl/go-mod-cache" GO_MOD_ARGS="-modcacherw" /usr/bin/env bash ../../lang/golang//golang-build.sh cache_cleanup
touch /home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.built
rm -rf /home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.pkgdir/mosdns.installed /home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.pkgdir/mosdns
mkdir -p /home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.pkgdir/mosdns
CONFIG_GOLANG_MOD_CACHE_WORLD_READABLE="" GO_BUILD_CACHE_DIR="/home/evine/lede/tmp/go-build" GO_MOD_CACHE_DIR="/home/evine/lede/dl/go-mod-cache" GO_MOD_ARGS="-modcacherw" GO_PKG="github.com/IrineSistiana/mosdns" GO_INSTALL_EXTRA="" GO_INSTALL_ALL="" GO_SOURCE_ONLY="" GO_BUILD_PKG="github.com/IrineSistiana/mosdns/..." GO_EXCLUDES="" GO_GO_GENERATE="" GO_INSTALL_BIN_PATH="/usr/bin" BUILD_DIR="/home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3" GO_BUILD_DIR="/home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.go_work/build" GO_BUILD_BIN_DIR="/home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.go_work/build/bin" GO_BUILD_DEPENDS_PATH="/usr/share/gocode" GO_BUILD_DEPENDS_SRC="/home/evine/lede/staging_dir/target-x86_64_musl/usr/share/gocode/src" /usr/bin/env bash ../../lang/golang//golang-build.sh install_bin "/home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.pkgdir/mosdns"
touch /home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.pkgdir/mosdns.installed
mkdir -p /home/evine/lede/staging_dir/target-x86_64_musl/root-x86/stamp
SHELL= flock /home/evine/lede/tmp/.root-copy.flock -c 'cp -fpR /home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.pkgdir/mosdns/. /home/evine/lede/staging_dir/target-x86_64_musl/root-x86/'
touch /home/evine/lede/staging_dir/target-x86_64_musl/root-x86/stamp/.mosdns_installed
mkdir -p /home/evine/lede/bin/targets/x86/64/packages /home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/ipkg-x86_64/mosdns/CONTROL /home/evine/lede/staging_dir/target-x86_64_musl/pkginfo
CONFIG_GOLANG_MOD_CACHE_WORLD_READABLE="" GO_BUILD_CACHE_DIR="/home/evine/lede/tmp/go-build" GO_MOD_CACHE_DIR="/home/evine/lede/dl/go-mod-cache" GO_MOD_ARGS="-modcacherw" GO_PKG="github.com/IrineSistiana/mosdns" GO_INSTALL_EXTRA="" GO_INSTALL_ALL="" GO_SOURCE_ONLY="" GO_BUILD_PKG="github.com/IrineSistiana/mosdns/..." GO_EXCLUDES="" GO_GO_GENERATE="" GO_INSTALL_BIN_PATH="/usr/bin" BUILD_DIR="/home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3" GO_BUILD_DIR="/home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.go_work/build" GO_BUILD_BIN_DIR="/home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.go_work/build/bin" GO_BUILD_DEPENDS_PATH="/usr/share/gocode" GO_BUILD_DEPENDS_SRC="/home/evine/lede/staging_dir/target-x86_64_musl/usr/share/gocode/src" /usr/bin/env bash ../../lang/golang//golang-build.sh install_bin "/home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/ipkg-x86_64/mosdns"
find /home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/ipkg-x86_64/mosdns -name 'CVS' -o -name '.svn' -o -name '.#*' -o -name '*~'| xargs -r rm -rf
export CROSS="x86_64-openwrt-linux-musl-"  NO_RENAME=1 ; NM="x86_64-openwrt-linux-musl-nm" STRIP="x86_64-openwrt-linux-musl-strip --strip-all" STRIP_KMOD="/home/evine/lede/scripts/strip-kmod.sh" PATCHELF="/home/evine/lede/staging_dir/host/bin/patchelf" /home/evine/lede/scripts/rstrip.sh /home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/ipkg-x86_64/mosdns
rstrip.sh: /home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/ipkg-x86_64/mosdns/usr/bin/mosdns: executable
(cd /home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/ipkg-x86_64/mosdns/CONTROL; ( echo "$CONTROL"; printf "Description: "; echo "$DESCRIPTION" | sed -e 's,^[[:space:]]*, ,g'; ) > control; chmod 644 control; ( echo "#!/bin/sh"; echo "[ \"\${IPKG_NO_SCRIPT}\" = \"1\" ] && exit 0"; echo "[ -s "\${IPKG_INSTROOT}/lib/functions.sh" ] || exit 0"; echo ". \${IPKG_INSTROOT}/lib/functions.sh"; echo "default_postinst \$0 \$@"; ) > postinst; ( echo "#!/bin/sh"; echo "[ -s "\${IPKG_INSTROOT}/lib/functions.sh" ] || exit 0"; echo ". \${IPKG_INSTROOT}/lib/functions.sh"; echo "default_prerm \$0 \$@"; ) > prerm; chmod 0755 postinst prerm;  )
install -d -m0755 /home/evine/lede/bin/packages/x86_64/packages
/home/evine/lede/staging_dir/host/bin/fakeroot /home/evine/lede/staging_dir/host/bin/bash /home/evine/lede/scripts/ipkg-build -m "" /home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/ipkg-x86_64/mosdns /home/evine/lede/bin/packages/x86_64/packages
Packaged contents of /home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/ipkg-x86_64/mosdns into /home/evine/lede/bin/packages/x86_64/packages/mosdns_5.1.3-1_x86_64.ipk
echo "mosdns" >> /home/evine/lede/staging_dir/target-x86_64_musl/pkginfo/mosdns.default.install
rm -rf /home/evine/lede/tmp/stage-mosdns
mkdir -p /home/evine/lede/tmp/stage-mosdns/host /home/evine/lede/staging_dir/target-x86_64_musl/packages
CONFIG_GOLANG_MOD_CACHE_WORLD_READABLE="" GO_BUILD_CACHE_DIR="/home/evine/lede/tmp/go-build" GO_MOD_CACHE_DIR="/home/evine/lede/dl/go-mod-cache" GO_MOD_ARGS="-modcacherw" GO_PKG="github.com/IrineSistiana/mosdns" GO_INSTALL_EXTRA="" GO_INSTALL_ALL="" GO_SOURCE_ONLY="" GO_BUILD_PKG="github.com/IrineSistiana/mosdns/..." GO_EXCLUDES="" GO_GO_GENERATE="" GO_INSTALL_BIN_PATH="/usr/bin" BUILD_DIR="/home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3" GO_BUILD_DIR="/home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.go_work/build" GO_BUILD_BIN_DIR="/home/evine/lede/build_dir/target-x86_64_musl/mosdns-5.1.3/.go_work/build/bin" GO_BUILD_DEPENDS_PATH="/usr/share/gocode" GO_BUILD_DEPENDS_SRC="/home/evine/lede/staging_dir/target-x86_64_musl/usr/share/gocode/src" /usr/bin/env bash ../../lang/golang//golang-build.sh install_src "/home/evine/lede/tmp/stage-mosdns"
find /home/evine/lede/tmp/stage-mosdns -name '*.la' | xargs -r rm -f; 
if [ -f /home/evine/lede/staging_dir/target-x86_64_musl/packages/mosdns.list ]; then /home/evine/lede/scripts/clean-package.sh "/home/evine/lede/staging_dir/target-x86_64_musl/packages/mosdns.list" "/home/evine/lede/staging_dir/target-x86_64_musl"; fi
if [ -d /home/evine/lede/tmp/stage-mosdns ]; then (cd /home/evine/lede/tmp/stage-mosdns; find ./ > /home/evine/lede/tmp/stage-mosdns.files);  SHELL= flock /home/evine/lede/tmp/.staging-dir.flock -c ' mv /home/evine/lede/tmp/stage-mosdns.files /home/evine/lede/staging_dir/target-x86_64_musl/packages/mosdns.list && cp -fpR /home/evine/lede/tmp/stage-mosdns/* /home/evine/lede/staging_dir/target-x86_64_musl/; '; fi
rm -rf /home/evine/lede/tmp/stage-mosdns
touch /home/evine/lede/staging_dir/target-x86_64_musl/stamp/.mosdns_installed
make[2]: Leaving directory '/home/evine/lede/feeds/packages/net/mosdns'
time: package/feeds/packages/mosdns/compile#59.69#9.21#19.12
make[1]: Leaving directory '/home/evine/lede'
```
Run tested: 
```
root@OpenWrt:~# mosdns --help
Usage:
  mosdns [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  config      Tools that can generate/convert mosdns config file.
  help        Help about any command
  probe       Run some server tests.
  service     Manage mosdns as a system service.
  start       Start mosdns main program.
  version     Print out version info and exit.

Flags:
  -h, --help   help for mosdns

Use "mosdns [command] --help" for more information about a command.
```

Description:
