### PR TITLE
zerotier: update to 1.12.1

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zerotier
-PKG_VERSION:=1.10.6
+PKG_VERSION:=1.12.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerotier/ZeroTierOne/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=3f0b59e0c290b18b93fddee1f7b927209538d84a88343b2f3ac61a6bf3c87910
+PKG_HASH:=c6758a04f161bba1c0ef11fce991029a645ede381ae3862a25a2f5145aaffca8
 PKG_BUILD_DIR:=$(BUILD_DIR)/ZeroTierOne-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>
@@ -20,13 +20,14 @@ PKG_LICENSE_FILES:=LICENSE.txt
 
 PKG_ASLR_PIE:=0
 PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=gc-sections
 
 include $(INCLUDE_DIR)/package.mk
 
 define Package/zerotier
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+libpthread +libstdcpp +kmod-tun +ip +libminiupnpc +libnatpmp
+  DEPENDS:=+libpthread +libstdcpp +kmod-tun +ip +libminiupnpc +libnatpmp +libatomic
   TITLE:=Create flat virtual Ethernet networks of almost unlimited size
   URL:=https://www.zerotier.com
   SUBMENU:=VPN
@@ -58,8 +59,8 @@ endif
 endef
 
 # Make binary smaller
-TARGET_CFLAGS += -ffunction-sections -fdata-sections
-TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
+TARGET_CFLAGS += -Wl,-z,noexecstack
+TARGET_LDFLAGS += -Wl,--as-needed -Wl,-z,noexecstack
 
 define Package/zerotier/conffiles
 /etc/config/zerotier

--- a/net/zerotier/patches/0001-fix-miniupnpc-natpmp-include-paths.patch
+++ b/net/zerotier/patches/0001-fix-miniupnpc-natpmp-include-paths.patch
@@ -1,11 +1,12 @@
-From 2c513f0db50eaee5623d58ac024d62142f4ac782 Mon Sep 17 00:00:00 2001
+From 8b30e8617720c2a540c84c5c00508e8081e9f06e Mon Sep 17 00:00:00 2001
 From: Moritz Warning <moritzwarning@web.de>
-Date: Mon, 4 Jul 2022 00:09:24 +0200
-Subject: [PATCH 1/2] fix makefile
+Date: Sun, 27 Aug 2023 23:26:33 +0200
+Subject: [PATCH 1/5] fix miniupnpc/natpmp include paths
 
+Signed-off-by: Moritz Warning <moritzwarning@web.de>
 ---
- make-linux.mk | 14 +++++++-------
- 1 file changed, 7 insertions(+), 7 deletions(-)
+ make-linux.mk | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
 
 --- a/make-linux.mk
 +++ b/make-linux.mk
@@ -29,32 +30,3 @@ Subject: [PATCH 1/2] fix makefile
  	ONE_OBJS+=ext/libnatpmp/natpmp.o ext/libnatpmp/getgateway.o
  else
  	LDLIBS+=-lnatpmp
-@@ -70,7 +70,7 @@ else
- 	override CFLAGS+=-Wall -Wno-deprecated -pthread $(INCLUDES) -DNDEBUG $(DEFS)
- 	CXXFLAGS?=-O3 -fstack-protector
- 	override CXXFLAGS+=-Wall -Wno-deprecated -std=c++17 -pthread $(INCLUDES) -DNDEBUG $(DEFS)
--	LDFLAGS=-pie -Wl,-z,relro,-z,now
-+	LDFLAGS=-Wl,-z,relro,-z,now
- 	RUSTFLAGS=--release
- endif
- 
-@@ -316,7 +316,7 @@ ifeq ($(ZT_CONTROLLER),1)
- endif
- 
- # ARM32 hell -- use conservative CFLAGS
--ifeq ($(ZT_ARCHITECTURE),3)
-+ifeq (0,3)
- 	ifeq ($(shell if [ -e /usr/bin/dpkg ]; then dpkg --print-architecture; fi),armel)
- 		override CFLAGS+=-march=armv5t -mfloat-abi=soft -msoft-float -mno-unaligned-access -marm
- 		override CXXFLAGS+=-march=armv5t -mfloat-abi=soft -msoft-float -mno-unaligned-access -marm
-@@ -343,8 +343,8 @@ ifeq ($(ZT_USE_ARM32_NEON_ASM_CRYPTO),1)
- endif
- 
- # Position Independence
--override CFLAGS+=-fPIC -fPIE
--override CXXFLAGS+=-fPIC -fPIE
-+#override CFLAGS+=-fPIC -fPIE
-+#override CXXFLAGS+=-fPIC -fPIE
- 
- .PHONY: all
- all:	one

--- a/net/zerotier/patches/0002-remove-PIE-options.patch
+++ b/net/zerotier/patches/0002-remove-PIE-options.patch
@@ -1,0 +1,41 @@
+From 9b97099560a79529f2b5a748e73164ae038d2b76 Mon Sep 17 00:00:00 2001
+From: Moritz Warning <moritzwarning@web.de>
+Date: Sun, 27 Aug 2023 23:27:33 +0200
+Subject: [PATCH 2/5] remove PIE options
+
+Signed-off-by: Moritz Warning <moritzwarning@web.de>
+---
+ make-linux.mk | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+--- a/make-linux.mk
++++ b/make-linux.mk
+@@ -70,7 +70,7 @@ else
+ 	override CFLAGS+=-Wall -Wno-deprecated -pthread $(INCLUDES) -DNDEBUG $(DEFS)
+ 	CXXFLAGS?=-O3 -fstack-protector
+ 	override CXXFLAGS+=-Wall -Wno-deprecated -std=c++17 -pthread $(INCLUDES) -DNDEBUG $(DEFS)
+-	LDFLAGS=-pie -Wl,-z,relro,-z,now
++	LDFLAGS=-Wl,-z,relro,-z,now
+ 	RUSTFLAGS=--release
+ endif
+ 
+@@ -327,7 +327,7 @@ ifeq ($(ZT_CONTROLLER),1)
+ endif
+ 
+ # ARM32 hell -- use conservative CFLAGS
+-ifeq ($(ZT_ARCHITECTURE),3)
++ifeq (0,3)
+ 	ifeq ($(shell if [ -e /usr/bin/dpkg ]; then dpkg --print-architecture; fi),armel)
+ 		override CFLAGS+=-march=armv5t -mfloat-abi=soft -msoft-float -mno-unaligned-access -marm
+ 		override CXXFLAGS+=-march=armv5t -mfloat-abi=soft -msoft-float -mno-unaligned-access -marm
+@@ -354,8 +354,8 @@ ifeq ($(ZT_USE_ARM32_NEON_ASM_CRYPTO),1)
+ endif
+ 
+ # Position Independence
+-override CFLAGS+=-fPIC -fPIE
+-override CXXFLAGS+=-fPIC -fPIE
++#override CFLAGS+=-fPIC -fPIE
++#override CXXFLAGS+=-fPIC -fPIE
+ 
+ # Non-executable stack
+ override ASFLAGS+=--noexecstack

--- a/net/zerotier/patches/0003-fix-compilation-for-arm_cortex-a7-neon.patch
+++ b/net/zerotier/patches/0003-fix-compilation-for-arm_cortex-a7-neon.patch
@@ -1,7 +1,7 @@
-From 819232a2b5a09d7aa3cacb8dcf7c2e28afde1b06 Mon Sep 17 00:00:00 2001
+From 1689085363cf87deb3877139931a8a88d8c7bcd3 Mon Sep 17 00:00:00 2001
 From: Moritz Warning <moritzwarning@web.de>
 Date: Mon, 4 Jul 2022 00:10:52 +0200
-Subject: [PATCH 2/2] fix compilation for arm_cortex-a7+neon
+Subject: [PATCH 3/5] fix compilation for arm_cortex-a7+neon
 
 Fixes "error: 'vrbitq_u8' was not declared in this scope"
 

--- a/net/zerotier/patches/0004-add-missing-libatomic.patch
+++ b/net/zerotier/patches/0004-add-missing-libatomic.patch
@@ -1,0 +1,21 @@
+From b3879d721734862aa64433f7faf124a0862da029 Mon Sep 17 00:00:00 2001
+From: Moritz Warning <moritzwarning@web.de>
+Date: Sun, 27 Aug 2023 22:27:12 +0200
+Subject: [PATCH 4/5] add missing libatomic
+
+Signed-off-by: Moritz Warning <moritzwarning@web.de>
+---
+ make-linux.mk | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/make-linux.mk
++++ b/make-linux.mk
+@@ -11,7 +11,7 @@ endif
+ 
+ INCLUDES?=-Izeroidc/target -isystem ext -Iext/prometheus-cpp-lite-1.0/core/include -Iext-prometheus-cpp-lite-1.0/3rdparty/http-client-lite/include -Iext/prometheus-cpp-lite-1.0/simpleapi/include
+ DEFS?=
+-LDLIBS?=
++LDLIBS?=-latomic
+ DESTDIR?=
+ 
+ include objects.mk

--- a/net/zerotier/patches/0005-remove-noexecstack.patch
+++ b/net/zerotier/patches/0005-remove-noexecstack.patch
@@ -1,0 +1,21 @@
+From adcc68c6c3de8460bd6263d3478873953a4cf894 Mon Sep 17 00:00:00 2001
+From: Moritz Warning <moritzwarning@web.de>
+Date: Mon, 28 Aug 2023 09:48:28 +0200
+Subject: [PATCH 5/5] remove noexecstack
+
+The compilers for arm_cortex-a9 do not recognize this argument.
+---
+ make-linux.mk | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/make-linux.mk
++++ b/make-linux.mk
+@@ -358,7 +358,7 @@ endif
+ #override CXXFLAGS+=-fPIC -fPIE
+ 
+ # Non-executable stack
+-override ASFLAGS+=--noexecstack
++# override ASFLAGS+=--noexecstack
+ 
+ .PHONY: all
+ all:	one


### PR DESCRIPTION
* split up "fix makefile" patch logical distinct parts
* add libatomic dependency needed for prometheus-cpp-lite-1.0
* refresh patch series
* improve warning message in init script

Signed-off-by: Moritz Warning <moritzwarning@web.de>