### PR TITLE
docker: revert kernel modules support to default

### DIFF
--- a/utils/dockerd/Config.in
+++ b/utils/dockerd/Config.in
@@ -62,13 +62,13 @@ menu "Network"
 
 	config DOCKER_NET_MACVLAN
 		bool "Includes macvlan kernel modules"
-		default n
+		default y
 		select PACKAGE_kmod-macvlan
 		select PACKAGE_kmod-dummy
 
 	config DOCKER_NET_TFTP
 		bool "Includes ftp/tftp client kernel modules"
-		default y
+		default n
 		select PACKAGE_kmod-nf-nathelper
 		select PACKAGE_kmod-nf-nathelper-extra
 endmenu
@@ -89,7 +89,7 @@ menu "Storage"
 
 	config DOCKER_STO_BTRFS
 		bool "Enables support for btrfs as the backing filesystem"
-		default y
+		default n
 		select KERNEL_BTRFS_FS_POSIX_ACL
 		select PACKAGE_btrfs-progs
 endmenu


### PR DESCRIPTION
上次的 pr #723 将一部分非必要的模块默认启用了，这个 pr 是恢复原来默认的配置值