### PR TITLE
perl: fix compilation with musl 1.2.4

### DIFF
--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -11,7 +11,7 @@ include perlver.mk
 
 PKG_NAME:=perl
 PKG_VERSION:=$(PERL_VERSION)
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_SOURCE_URL:=\
 		https://cpan.metacpan.org/src/5.0 \

--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -40,6 +40,10 @@ HOST_BUILD_PARALLEL:=1
 # Variables used during configuration/build
 HOST_PERL_PREFIX:=$(STAGING_DIR_HOSTPKG)/usr
 
+ifneq ($(CONFIG_USE_MUSL),)
+  TARGET_CFLAGS += -D_LARGEFILE64_SOURCE
+endif
+
 # Filter -g3, it will break Compress-Raw-Zlib
 TARGET_CFLAGS_PERL:=$(patsubst -g3,-g,$(TARGET_CFLAGS))
 TARGET_CPPFLAGS_PERL:=$(patsubst -g3,-g,$(TARGET_CPPFLAGS))


### PR DESCRIPTION
fix `perl` compilation with musl 1.2.4

Reference: https://github.com/openwrt/packages/pull/21069