### PR TITLE
btrfs-progs: fix compilation with musl 1.2.4

### DIFF
--- a/utils/btrfs-progs/Makefile
+++ b/utils/btrfs-progs/Makefile
@@ -25,6 +25,10 @@ PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 
+ifneq ($(CONFIG_USE_MUSL),)
+  TARGET_CFLAGS += -D_LARGEFILE64_SOURCE
+endif
+
 define Package/btrfs-progs
   SECTION:=utils
   CATEGORY:=Utilities


### PR DESCRIPTION
Fix `btrfs-progs` compilation with musl 1.2.4