### PR TITLE
aliyundrive-webdav: bump version to 2.3.3

### DIFF
--- a/multimedia/aliyundrive-webdav/Makefile
+++ b/multimedia/aliyundrive-webdav/Makefile
@@ -1,36 +1,38 @@
-# SPDX-License-Identifier: GPL-2.0-only
-#
-# Copyright (C) 2017-2020 Yousong Zhou <yszhou4tech@gmail.com>
-# Copyright (C) 2021-2023 ImmortalWrt.org
-
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aliyundrive-webdav
-PKG_VERSION:=2.3.2
+PKG_VERSION:=2.3.3
 PKG_RELEASE:=1
-
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/messense/aliyundrive-webdav.git
-PKG_SOURCE_VERSION:=7ba03f68fd5200802000997548a4a2b33b404324
-PKG_MIRROR_HASH:=05826a036c266d58c784b08b59f6c948857947b78da3e76ed9847bd69a7d7d4b
 
 PKG_LICENSE:=MIT
 PKG_MAINTAINER:=messense <messense@icloud.com>
 
-PKG_BUILD_DEPENDS:=rust/host
+PKG_LIBC:=musl
+ifeq ($(ARCH),arm)
+  PKG_LIBC:=musleabi
 
-RUST_PKG_FEATURES:=rustls-tls atomic64 native-tls native-tls-vendored
+  ARM_CPU_FEATURES:=$(word 2,$(subst +,$(space),$(call qstrip,$(CONFIG_CPU_TYPE))))
+  ifneq ($(filter $(ARM_CPU_FEATURES),vfp vfpv2),)
+    PKG_LIBC:=musleabihf
+  endif
+endif
+
+PKG_ARCH=$(ARCH)
+ifeq ($(ARCH),i386)
+  PKG_ARCH:=i686
+endif
+
+PKG_SOURCE:=aliyundrive-webdav-v$(PKG_VERSION).$(PKG_ARCH)-unknown-linux-$(PKG_LIBC).tar.gz
+PKG_SOURCE_URL:=https://github.com/messense/aliyundrive-webdav/releases/download/v$(PKG_VERSION)/
+PKG_HASH:=skip
 
 include $(INCLUDE_DIR)/package.mk
-include ../../lang/rust/rust-package.mk
 
 define Package/aliyundrive-webdav
   SECTION:=multimedia
   CATEGORY:=Multimedia
   TITLE:=WebDAV server for AliyunDrive
   URL:=https://github.com/messense/aliyundrive-webdav
-  DEPENDS:=$$(RUST_ARCH_DEPENDS)
 endef
 
 define Package/aliyundrive-webdav/description
@@ -41,10 +43,30 @@ define Package/aliyundrive-webdav/conffiles
 /etc/config/aliyundrive-webdav
 endef
 
+define Download/sha256sum
+	FILE:=$(PKG_SOURCE).sha256
+	URL_FILE:=$(FILE)
+	URL:=$(PKG_SOURCE_URL)
+	HASH:=skip
+endef
+$(eval $(call Download,sha256sum))
+
+define Build/Prepare
+	mv $(DL_DIR)/$(PKG_SOURCE).sha256 .
+	cp $(DL_DIR)/$(PKG_SOURCE) .
+	shasum -a 256 -c $(PKG_SOURCE).sha256
+	rm $(PKG_SOURCE).sha256 $(PKG_SOURCE)
+
+	tar -C $(PKG_BUILD_DIR)/ -zxf $(DL_DIR)/$(PKG_SOURCE)
+endef
+
+define Build/Compile
+	echo "aliyundrive-webdav using precompiled binary."
+endef
+
 define Package/aliyundrive-webdav/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/target/$(RUSTC_TARGET_ARCH)/release/aliyundrive-webdav $(1)/usr/bin/
-
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/aliyundrive-webdav $(1)/usr/bin/aliyundrive-webdav
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/aliyundrive-webdav.init $(1)/etc/init.d/aliyundrive-webdav
 	$(INSTALL_DIR) $(1)/etc/config

--- a/multimedia/aliyundrive-webdav/files/aliyundrive-webdav.config
+++ b/multimedia/aliyundrive-webdav/files/aliyundrive-webdav.config
@@ -4,6 +4,7 @@ config server
     option refresh_token ''
     option host '0.0.0.0'
     option port '8080'
+    option drive_type ''
     option auth_user ''
     option auth_password ''
     option read_buffer_size '10485760'

--- a/multimedia/aliyundrive-webdav/files/aliyundrive-webdav.init
+++ b/multimedia/aliyundrive-webdav/files/aliyundrive-webdav.init
@@ -28,6 +28,7 @@ start_service() {
       local root=$(uci_get_by_type server root /)
       local tls_cert=$(uci_get_by_type server tls_cert)
       local tls_key=$(uci_get_by_type server tls_key)
+      local drive_type=$(uci_get_by_type server drive_type)
 
       local extra_options="--auto-index"
 
@@ -68,6 +69,10 @@ start_service() {
 
       if [[ ! -z "$tls_cert" && ! -z "$tls_key" ]]; then
         extra_options="$extra_options --tls-cert $tls_cert --tls-key $tls_key"
+      fi
+
+      if [[ ! -z "$drive_type" ]]; then
+        extra_options="$extra_options --drive-type $drive_type"
       fi
 
       procd_open_instance


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: x86_64 r6565-01c841d07
Run tested: x86_64 r6565-01c841d07

Description:
Pull from messense's repository: aliyundrive-webdav.