### PR TITLE
docker: update to 26.1.1

### DIFF
--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker
-PKG_VERSION:=26.1.0
+PKG_VERSION:=26.1.1
 PKG_RELEASE:=$(AUTORELEASE)
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -10,8 +10,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/docker/cli
 PKG_GIT_REF:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=742d8297c8222d4c6e1a5840d1604e215c94cbbee1c275a12fb98abd572083de
-PKG_GIT_SHORT_COMMIT:=9714adc # SHA1 used within the docker executables
+PKG_HASH:=d28ecafe22a1051b9e78321047e90dd636db4310a388e7681ac144edbf178561
+PKG_GIT_SHORT_COMMIT:=4cf5afa # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 

--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dockerd
-PKG_VERSION:=26.1.0
+PKG_VERSION:=26.1.1
 PKG_RELEASE:=$(AUTORELEASE)
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -10,8 +10,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/moby/moby
 PKG_GIT_REF:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=7a59781fe9e1d74d1ada53624f0bde909de503964b729dc9dfb21e56c3a9b8ae
-PKG_GIT_SHORT_COMMIT:=c8af8eb # SHA1 used within the docker executables
+PKG_HASH:=d0b3b2083d1ef5144092c89bcf28519fa3cdab3ab6bfb3a6499ec5cf05961c2c
+PKG_GIT_SHORT_COMMIT:=ac2de55 # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 


### PR DESCRIPTION
Update Docker to 26.1.1


Compile tested: CncTion J4125-4L Intel(R) Celeron(R) J4125 CPU,OpenWrt R24.5.1 LuCI Master (git-24.126.79400-c7873ae)
Run tested: CncTion J4125-4L Intel(R) Celeron(R) J4125 CPU,OpenWrt R24.5.1 LuCI Master (git-24.126.79400-c7873ae)

Description: Docker 26.1.0 still encounters the problem of "superfluous response.WriteHeader" error logs，Update docker version to 26.1.1 try to fix it .

See https://github.com/moby/moby/issues/47448 https://github.com/open-telemetry/opentelemetry-go-contrib/issues/5438 for more info.

![111](https://github.com/coolsnowwolf/packages/assets/38988286/2b47398e-9da2-4a36-8b57-069638e4731c)

