### PR TITLE
speedtest-go: update to 1.7.5

### DIFF
--- a/net/speedtest-go/Makefile
+++ b/net/speedtest-go/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=speedtest-go
-PKG_VERSION:=1.7.0
+PKG_VERSION:=1.7.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/showwin/speedtest-go/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=0e22827a30ee775893e3ca701e2c45b7bdace330d75639423fb00b15075a8015
+PKG_HASH:=c18d7e74171b739a10e6b00e426f9f5fbf4d1dde345f3e20d14df9bbe2dc1aaf
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: TeleostNaCl [teleostnacl@gmail.com](mailto:teleostnacl@gmail.com)

Compile tested: MediaTek Ralink MIPS MT7621 based boards Phicomm K2P Powered by LuCI Master (git-24.096.15376-b029f06)

Run tested: MediaTek Ralink MIPS MT7621 based boards Phicomm K2P Powered by LuCI Master (git-24.096.15376-b029f06)

Description: Synchronize upstream updates: https://github.com/showwin/speedtest-go