### PR TITLE
qemu: Remove --disable-hax

### DIFF
--- a/utils/qemu/Makefile
+++ b/utils/qemu/Makefile
@@ -336,7 +336,6 @@ CONFIGURE_ARGS +=			\
 
 # accel
 CONFIGURE_ARGS +=			\
-	--disable-hax			\
 	--disable-hvf			\
 	--disable-whpx			\
 	--disable-xen			\


### PR DESCRIPTION
unknown option --disable-hax

* --disable-hax is no longer supported

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
