### PR TITLE
uugamebooster: bump to v4.14.4

### DIFF
--- a/net/uugamebooster/Makefile
+++ b/net/uugamebooster/Makefile
@@ -12,7 +12,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uugamebooster
-PKG_VERSION:=v3.15.0
+PKG_VERSION:=v4.14.4
 PKG_RELEASE:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -31,22 +31,22 @@ endef
 
 ifeq ($(ARCH),arm)
 	UU_ARCH:=arm
-	PKG_MD5SUM:=0b6a8d04f0b72d9270da295e3eb0d924
+	PKG_MD5SUM:=9d524db2593abd58a2977ff844e8db65
 endif
 
 ifeq ($(ARCH),aarch64)
 	UU_ARCH:=aarch64
-	PKG_MD5SUM:=22ac7bac2e3c517b0120f182b6d406ad
+	PKG_MD5SUM:=3ce3e920432e59825bc84113fbbf2a8e
 endif
 
 ifeq ($(ARCH),mipsel)
 	UU_ARCH:=mipsel
-	PKG_MD5SUM:=de7b87ef7c713d9dd97423d0131eeafd
+	PKG_MD5SUM:=d65b3295d5770e4a15ff9e8a4b83bc2a
 endif
 
 ifeq ($(ARCH),x86_64)
 	UU_ARCH:=x86_64
-	PKG_MD5SUM:=983e1873e74c06690e32bb7bae12883e
+	PKG_MD5SUM:=b9ca050a6ed3658b460150b02f7772e6
 endif
 
 PKG_SOURCE_URL:=https://uu.gdl.netease.com/uuplugin/openwrt-$(UU_ARCH)/$(PKG_VERSION)/uu.tar.gz?


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
uugamebooster bump to v4.14.4