### PR TITLE
nginx-util: fix compilation with GCC13

### DIFF
--- a/net/nginx-util/Makefile
+++ b/net/nginx-util/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx-util
 PKG_VERSION:=1.6
-PKG_RELEASE:=15
+PKG_RELEASE:=16
 PKG_MAINTAINER:=Peter Stadler <peter.stadler@student.uibk.ac.at>
 
 include $(INCLUDE_DIR)/package.mk

--- a/net/nginx-util/src/ubus-cxx.hpp
+++ b/net/nginx-util/src/ubus-cxx.hpp
@@ -159,7 +159,7 @@ class message {
             both = keys;
         }
         both = concat(std::move(both), std::move(key_filter)...);
-        return std::move(message{msg, std::move(both)});
+        return message{msg, std::move(both)};
     }
 
     inline ~message() = default;


### PR DESCRIPTION
Maintainer: Peter Stadler
Compile tested: armv7, PHICOMM K3, master (85df79d)
Run tested: armv7, PHICOMM K3, master (85df79d), passed

Description:
https://github.com/coolsnowwolf/lede/pull/12212 requires GCC 13.3, which would report an error on nginx-util.
The upstream has fixed it in https://github.com/openwrt/packages/commit/d71e28de375edc17ae0e0c6f735a870759c9a3e8.