### PR TITLE
Softethervpn5: Fix IPv6 listening by updating to version 5.02.5185

### DIFF
--- a/net/softethervpn5/Makefile
+++ b/net/softethervpn5/Makefile
@@ -3,7 +3,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=softethervpn5
-PKG_VERSION:=5.02.5180
+PKG_VERSION:=5.02.5185
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
@@ -12,7 +12,7 @@ PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE_URL:=https://github.com/SoftEtherVPN/SoftEtherVPN/releases/download/$(PKG_VERSION)/
 PKG_SOURCE:=SoftEtherVPN-$(PKG_VERSION).tar.xz
-PKG_HASH:=b5649a8ea3cc6477325e09e2248ef708d434ee3b2251eb8764bcfc15fb1de456
+PKG_HASH:=f0d3f6d841b1d8e4478f25771fa6f58717fed13de6c28dec36bf497c7b035853
 
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/SoftEtherVPN-$(PKG_VERSION)
 PKG_BUILD_DIR:=$(BUILD_DIR)/SoftEtherVPN-$(PKG_VERSION)


### PR DESCRIPTION
Softethervpn 5.02.5180 has problems with IPv6 listening, updating to 5.02.5185 solves this issue.

Maintainer: @hellcatjack
Compile tested: x86-64 OpenWrt R24.7.7
Run tested: x86-64 OpenWrt R24.7.7 IPv4&v6 listening works
Description:
Softethervpn 5.02.5180 has problems with IPv6 listening cdaad87dd6b0f5809932fd24762795204dd1e501 , updating to 5.02.5185 solves this issue.