### PR TITLE
Update tailscale to 1.70.0

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
-PKG_VERSION:=1.68.1
+PKG_VERSION:=1.70.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=d7fe30282d2f5eabdc76a5a89f11d935ed3a5d93d55f5fd5b40f9a9f49e19490
+PKG_HASH:=8429728708f9694534489daa0a30af58be67f25742597940e7613793275c738f
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
已在 Lean's LEDE 最新 https://github.com/coolsnowwolf/lede/commit/062d85f8fd82ec53d4a505256583b3bdd19775fe 中成功使用 tailscale，编译无明显 error，运行无异常，请求合并

tailscale.com/admin/machines: 1.70.0-1 (OpenWrt)Linux 6.1.100 Connected