### PR TITLE
zerotier: bump to 1.14.1

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zerotier
-PKG_VERSION:=1.14.0
+PKG_VERSION:=1.14.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerotier/ZeroTierOne/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=7191623a81b0d1b552b9431e8864dd3420783ee518394ac1376cee6aaf033291
+PKG_HASH:=4f9f40b27c5a78389ed3f3216c850921f6298749e5819e9f2edabb2672ce9ca0
 PKG_BUILD_DIR:=$(BUILD_DIR)/ZeroTierOne-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>

--- a/net/zerotier/patches/0002-remove-PIE-options.patch
+++ b/net/zerotier/patches/0002-remove-PIE-options.patch
@@ -14,8 +14,8 @@ Signed-off-by: Moritz Warning <moritzwarning@web.de>
  	override CFLAGS+=-Wall -Wno-deprecated -pthread $(INCLUDES) -DNDEBUG $(DEFS)
  	CXXFLAGS?=-O3 -fstack-protector
  	override CXXFLAGS+=-Wall -Wno-deprecated -std=c++17 -pthread $(INCLUDES) -DNDEBUG $(DEFS)
--	LDFLAGS=-pie -Wl,-z,relro,-z,now
-+	LDFLAGS=-Wl,-z,relro,-z,now
+-	LDFLAGS?=-pie -Wl,-z,relro,-z,now
++	LDFLAGS?=-Wl,-z,relro,-z,now
  	ZT_CARGO_FLAGS=--release
  endif
  
@@ -38,4 +38,4 @@ Signed-off-by: Moritz Warning <moritzwarning@web.de>
 +#override CXXFLAGS+=-fPIC -fPIE
  
  # Non-executable stack
- override ASFLAGS+=--noexecstack
+ override LDFLAGS+=-Wl,-z,noexecstack

--- a/net/zerotier/patches/0005-remove-noexecstack.patch
+++ b/net/zerotier/patches/0005-remove-noexecstack.patch
@@ -14,8 +14,8 @@ The compilers for arm_cortex-a9 do not recognize this argument.
  #override CXXFLAGS+=-fPIC -fPIE
  
  # Non-executable stack
--override ASFLAGS+=--noexecstack
-+# override ASFLAGS+=--noexecstack
+-override LDFLAGS+=-Wl,-z,noexecstack
++# override LDFLAGS+=-Wl,-z,noexecstack
  
  .PHONY: all
  all:	one


### PR DESCRIPTION
Compile tested: Nanopi-R2S R5C
Run tested: Nanopi R5C

![image](https://github.com/user-attachments/assets/5538d646-572f-4b44-a5ca-922c0397961d)
