### PR TITLE
cloudflared: Update to 2024.12.2

### DIFF
--- a/net/cloudflared/Makefile
+++ b/net/cloudflared/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cloudflared
-PKG_VERSION:=2024.12.1
+PKG_VERSION:=2024.12.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/cloudflare/cloudflared/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=74794fbcdd7b71131799100d493cf70a8e126cb109f3d9e2abce55593df6a737
+PKG_HASH:=48b9c54d79419d0489baadb8cb54d5196e0ff17650fb9eff81de02989fa8b009
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
[Test Build](https://github.com/Internet1235/gh-action-sdk/actions/runs/12733246621)
