### PR TITLE
iperf: bump to 2.2.1

### DIFF
--- a/net/iperf/Makefile
+++ b/net/iperf/Makefile
@@ -8,15 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iperf
-PKG_VERSION:=2.1.8
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_VERSION:=2.2.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=8e2cf2fbc9d0d4d1cf9d109b1e328459f9622993dc9a4c5a7dc8a2088fb7beaf
+PKG_HASH:=754ab0a7e28033dbea81308ef424bc7df4d6e2fe31b60cc536b61b51fefbd8fb
 PKG_SOURCE_URL:=@SF/iperf2
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 PKG_LICENSE:=BSD-3-Clause
+PKG_CPE_ID:=cpe:/a:iperf_project:iperf
 
 PKG_BUILD_PARALLEL:=1
 

--- a/net/iperf/patches/020-fix-udp-checksum.patch
+++ b/net/iperf/patches/020-fix-udp-checksum.patch
@@ -1,0 +1,11 @@
+--- a/src/checksums.c
++++ b/src/checksums.c
+@@ -172,7 +172,7 @@ uint32_t udpchecksum(const void *l3pdu,
+     int i;
+ 
+     const struct udphdr *udp_hdr = (const struct udphdr *)l4pdu;
+-    if (!udp_hdr->check) {
++    if (!udp_hdr->uh_sum) {
+ 	if (v6)
+ 	    // v6 requires checksums
+ 	    return -1;


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
**[Test Build](https://github.com/Internet1235/gh-action-sdk/actions/runs/12723912568)**
