### PR TITLE
nfs-utils: enable nfsdcld

### DIFF
--- a/net/nfs-kernel-server/Makefile
+++ b/net/nfs-kernel-server/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nfs-kernel-server
 PKG_VERSION:=2.6.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_HASH:=26d46448982252e9e2c8346d10cf13e1143e7089c866f53e25db3359f3e9493c
 
 PKG_SOURCE_URL:=@SF/nfs
@@ -70,7 +70,7 @@ define Package/nfs-utils/Default
 	$(call Package/nfs-kernel-server/Default)
 	SECTION:=utils
 	CATEGORY:=Utilities
-	DEPENDS+= +NFS_KERNEL_SERVER_V4:libkeyutils +NFS_KERNEL_SERVER_V4:libdevmapper
+	DEPENDS+= +NFS_KERNEL_SERVER_V4:libkeyutils +NFS_KERNEL_SERVER_V4:libdevmapper +libevent2-core +libsqlite3
 	URL:=http://nfs.sourceforge.net/
 	MAINTAINER:=Peter Wagner <tripolar@gmx.at>
 endef
@@ -109,8 +109,6 @@ TARGET_LDFLAGS += -L$(STAGING_DIR)/usr/lib/libevent
 CONFIGURE_ARGS += \
 	--disable-caps \
 	--disable-gss \
-	--disable-nfsdcld \
-	--disable-nfsdcltrack \
 	--enable-shared \
 	--enable-static \
 	--with-rpcgen=internal \
@@ -202,7 +200,12 @@ endef
 
 define Package/nfs-utils/install
 	$(INSTALL_DIR) $(1)/sbin
+	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/sbin/mount.nfs $(1)/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/sbin/nfsdcltrack $(1)/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/nfsdcld $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/nfsdclddb $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/nfsdclnts $(1)/usr/sbin/
 	(cd $(1)/sbin; ln -sf mount.nfs mount.nfs4; ln -sf mount.nfs umount.nfs; ln -sf mount.nfs umount.nfs4)
 endef
 

--- a/net/nfs-kernel-server/files/nfsd.init
+++ b/net/nfs-kernel-server/files/nfsd.init
@@ -6,23 +6,26 @@ STOP=60
 
 USE_PROCD=1
 
-NFS_D=/var/lib/nfs
-RECOVERY_D=$NFS_D/v4recovery
-LOCK_D=/var/lib/nfs/sm
-VAR_NFS=/var/lib/nfs
+NFS_DIR="/var/lib/nfs"
+RECOVERY_DIR="$NFS_DIR/v4recovery"
+LOCK_DIR="/var/lib/nfs/sm"
+PROCFS_DIR="/proc/fs/nfsd"
+VAR_NFS_DIR="/var/lib/nfs"
+NFSDCLD_DIR="$NFS_DIR/nfsdcld"
+RPC_PIPEFS_DIR="/tmp/lib/nfs/rpc_pipefs"
 
 start_service() {
-	grep -q /proc/fs/nfsd /proc/mounts || \
-		mount -t nfsd nfsd /proc/fs/nfsd
-	mkdir -p $NFS_D
-	mkdir -p $RECOVERY_D
-	mkdir -p $LOCK_D
-	touch $NFS_D/rmtab
+	grep -q "$PROCFS_DIR" /proc/mounts || \
+	mount -t nfsd nfsd "$PROCFS_DIR"
+	mkdir -p "$NFS_DIR"
+	mkdir -p "$RECOVERY_DIR"
+	mkdir -p "$LOCK_DIR"
+	touch "$NFS_DIR/rmtab"
 
-	mkdir -p $VAR_NFS
-	chown nfs:nfs $VAR_NFS
+	mkdir -p "$VAR_NFS_DIR"
+	chown -R nfs:nfs "$VAR_NFS_DIR"
 
-	sysctl -w fs.nfs.nlm_tcpport=32777 fs.nfs.nlm_udpport=32777 > /dev/null
+	sysctl -w fs.nfs.nlm_tcpport=32777 fs.nfs.nlm_udpport=32777 >/dev/null
 
 	procd_open_instance
 	procd_set_param command /usr/sbin/rpc.statd -p 32778 -o 32779 -F
@@ -34,16 +37,38 @@ start_service() {
 	procd_open_instance
 	procd_set_param command /usr/sbin/rpc.mountd -p 32780 -F
 	procd_close_instance
+
+	# nfsdcld
+	if [ -x /usr/sbin/nfsdcld ]; then
+		mkdir -p "$NFSDCLD_DIR" "$RPC_PIPEFS_DIR"
+		chmod 755 "$NFSDCLD_DIR" "$RPC_PIPEFS_DIR"
+		grep -q "$RPC_PIPEFS_DIR" /proc/mounts || \
+		mount -t rpc_pipefs none "$RPC_PIPEFS_DIR"
+		procd_open_instance
+		procd_set_param command /usr/sbin/nfsdcld
+		procd_close_instance
+	fi
 }
 
 stop_service() {
-	rpc.nfsd 0 2> /dev/null
+	rpc.nfsd 0 2>/dev/null
 	/usr/sbin/exportfs -au
-	grep -q /proc/fs/nfsd /proc/mounts && \
-		umount /proc/fs/nfsd
+
+	# nfsdcld
+	if [ -x /usr/sbin/nfsdcld ]; then
+		pid=$(pgrep nfsdcld)
+		if [ -n "$pid" ]; then
+			kill "$pid"
+		fi
+		grep -q "$RPC_PIPEFS_DIR" /proc/mounts && \
+		umount "$RPC_PIPEFS_DIR"
+	fi
+
+	grep -q "$PROCFS_DIR" /proc/mounts && \
+	umount "$PROCFS_DIR"
 }
 
 service_triggers() {
-	local export_dirs="$(while read mp _r ; do echo -n "$mp " ; done < /etc/exports)"
+	local export_dirs="$(while read mp _r; do echo -n "$mp "; done </etc/exports)"
 	procd_add_reload_mount_trigger $export_dirs
 }


### PR DESCRIPTION
…LEGACY_CLIENT_TRACKING option, and in kernel 6.12, if CONFIG_NFSD_LEGACY_CLIENT_TRACKING is still enabled, the following kernel panic may occur:

[   65.168486] ------------[ cut here ]------------
[   65.173115] kernel BUG at fs/nfsd/nfs4recover.c:534!
[   65.178085] Internal error: Oops - BUG: 00000000f2000800 [#1] SMP
[   65.184178] Modules linked in: fast_classifier shortcut_fe_cm sch_pie ath9k ath9k_common rtw88_8822cu rtw88_8822c rtw88_8822bu rtw88_8822b rtw88_8821cu rtw88_8821c rtl8192cu rtl8192c_common rtl_usb rt2800usb rt2800lib rt2500usb pppoe ppp_async mt7921u mt7921e mt7921_common mt76x0u mt76x0_common l2tp_ppp iwlmvm iwldvm carl9170 ath9k_hw ath5k ath11k_pci ath11k ath10k_pci ath10k_core ath snd_usb_audio rtw88_usb rtw88_core rtlwifi rt2x00usb rt2x00lib rsi_usb rsi_91x rndis_host rfcomm pppox ppp_mppe ppp_generic nft_fib_inet nf_flow_table_inet mt792x_usb mt792x_lib mt76x2u mt76x2_common mt76x02_usb mt76x02_lib mt7663u mt7663_usb_sdio_common mt7615_common mt7601u mt76_usb mt76_connac_lib mt76 mac80211 iwlwifi ipt_REJECT hidp hci_uart ebtable_nat ebtable_filter ebtable_broute cfg80211 cdc_ether btusb btrtl btrsi btqca btmtk btintel btbcm br_netfilter bnep bluetooth ax88179_178a xt_u32 xt_time xt_tcpudp xt_tcpmss xt_string xt_statistic xt_state xt_socket xt_recent xt_quota xt_policy xt_pkttype xt_physdev xt_owner xt_nat
[   65.184401]  xt_multiport xt_mark xt_mac xt_limit xt_length xt_iprange xt_hl xt_helper xt_hashlimit xt_esp xt_ecn xt_dscp xt_conntrack xt_connmark xt_connlimit xt_connlabel xt_connbytes xt_comment xt_cluster xt_cgroup xt_bpf xt_addrtype xt_TRACE xt_TPROXY xt_TEE xt_TCPMSS xt_REDIRECT xt_NFQUEUE xt_NFLOG xt_NETMAP xt_MASQUERADE xt_LOG xt_LED xt_HL xt_FULLCONENAT xt_FLOWOFFLOAD xt_DSCP xt_CT xt_CLASSIFY xt_CHECKSUM wireguard usbnet usblp usb_wwan ums_usbat ums_sddr55 ums_sddr09 ums_karma ums_jumpshot ums_isd200 ums_freecom ums_datafab ums_cypress ums_alauda ts_fsm ts_bm tcp_bbr sunxi_wdt snd_usbmidi_lib slhc rfkill r8152 qrtr_mhi qrtr qmi_helpers nft_reject_ipv6 nft_reject_ipv4 nft_reject_inet nft_reject_bridge nft_reject nft_redir nft_quota nft_queue nft_numgen nft_nat nft_meta_bridge nft_masq nft_log nft_limit nft_hash nft_fwd_netdev nft_flow_offload nft_fib_ipv6 nft_fib_ipv4 nft_fib nft_dup_netdev nft_ct nft_chain_nat nfnetlink_queue nfnetlink_log nf_tproxy_ipv6 nf_tproxy_ipv4 nf_tables nf_socket_ipv6 nf_socket_ipv4
[   65.273977]  nf_reject_ipv4 nf_nat_tftp nf_nat_snmp_basic nf_nat_sip nf_nat_pptp nf_nat_irc nf_nat_h323 nf_nat_ftp nf_nat_amanda nf_log_syslog nf_flow_table nf_dup_netdev nf_dup_ipv6 nf_dup_ipv4 nf_conntrack_tftp nf_conntrack_snmp nf_conntrack_sip nf_conntrack_pptp nf_conntrack_netlink nf_conntrack_irc nf_conntrack_h323 nf_conntrack_ftp nf_conntrack_broadcast nf_conntrack_bridge ts_kmp nf_conntrack_amanda nf_conncount mhi macvlan iptable_raw iptable_nat iptable_mangle iptable_filter ipt_rpfilter ipt_ah ipt_ECN ip6table_raw ip6t_rpfilter ip_tables ebtables ebt_vlan ebt_stp ebt_snat ebt_redirect ebt_pkttype ebt_nflog ebt_mark_m ebt_mark ebt_log ebt_limit ebt_ip6 ebt_ip ebt_dnat ebt_arpreply ebt_arp ebt_among ebt_802_3 e1000e cordic cdc_acm bridge ax88796b arptable_filter arpt_mangle arp_tables ntfs3 sch_teql sch_sfq sch_multiq sch_gred sch_fq sch_codel em_text em_nbyte em_meta em_cmp act_skbmod act_simple act_pedit act_csum act_connmark sch_tbf sch_ingress sch_htb sch_hfsc em_u32 cls_u32 cls_route cls_matchall cls_fw
[   65.364083]  cls_flow cls_basic act_skbedit act_mirred act_gact gpio_beeper xt_set ip_set_list_set ip_set_hash_netportnet ip_set_hash_netport ip_set_hash_netnet ip_set_hash_netiface ip_set_hash_net ip_set_hash_mac ip_set_hash_ipportnet ip_set_hash_ipportip ip_set_hash_ipport ip_set_hash_ipmark ip_set_hash_ipmac ip_set_hash_ip ip_set_bitmap_port ip_set_bitmap_ipmac ip_set_bitmap_ip ip_set nfnetlink ip6table_nat nf_nat ip6t_NPT ip6t_rt ip6t_mh ip6t_ipv6header ip6t_hbh ip6t_frag ip6t_eui64 ip6t_ah ip6table_mangle ip6table_filter ip6_tables ip6t_REJECT x_tables nf_reject_ipv6 nfsv4 nfsv3 nfsd nfs_acl nfs bonding tls ip_gre gre ifb dummy l2tp_netlink l2tp_core rpcsec_gss_krb5 auth_rpcgss veth tun snd_rawmidi snd_hwdep udf lockd sunrpc grace isofs hfsplus hfs cdrom cifs nls_ucs2_utils netfs cifs_md4 cifs_arc4 dns_resolver vxlan shortcut_fe_ipv6 shortcut_fe uhci_hcd fsl_mph_dr_of ehci_fsl dm_mirror dm_region_hash dm_log dm_crypt dm_mod ohci_platform sunxi xhci_sunxi ohci_hcd phy_generic
[   65.540641] CPU: 3 UID: 0 PID: 12137 Comm: rpc.nfsd Not tainted 6.12.12-flippy-93+ #6
[   65.548488] Hardware name: V-Plus Cloud (DT)
[   65.552771] pstate: 60000005 (nZCv daif -PAN -UAO -TCO -DIT -SSBS BTYPE=--)
[   65.559729] pc : nfsd4_legacy_tracking_init+0x1d0/0x214 [nfsd]
[   65.565791] lr : nfsd4_legacy_tracking_init+0xb8/0x214 [nfsd]
[   65.571737] sp : ffff80008742bb10
[   65.575053] x29: ffff80008742bb20 x28: ffff000021bbb180 x27: ffff000007d27000
[   65.582192] x26: ffff80007a959c00 x25: ffff000007d27000 x24: ffff0000138a2f00
[   65.589326] x23: ffff000007d27000 x22: ffff80007a997378 x21: ffff80007a959000
[   65.596461] x20: ffff800082355780 x19: ffff80007a958ba0 x18: ffffffffffffffff
[   65.603596] x17: 20797265766f6365 x16: 7220657461747320 x15: 347653464e206568
[   65.610734] x14: 7420736120797265 x13: ffff800081ee6888 x12: 000000000000063c
[   65.617871] x11: 0000000000000214 x10: ffff800081f96888 x9 : ffff800081ee6888
[   65.625005] x8 : 00000000ffffdfff x7 : ffff800081f96888 x6 : 0000000000000001
[   65.632137] x5 : 0000000000000000 x4 : 0000000000000000 x3 : 0000000000000000
[   65.639271] x2 : 0000000000000000 x1 : ffff000021bbb180 x0 : ffff00001b705a80
[   65.646407] Call trace:
[   65.648854]  nfsd4_legacy_tracking_init+0x1d0/0x214 [nfsd]
[   65.654567]  nfsd4_client_tracking_init+0x170/0x1b4 [nfsd]
[   65.660245]  nfs4_state_start_net+0x230/0x3a8 [nfsd]
[   65.665438]  nfsd_svc+0x190/0x2d0 [nfsd]
[   65.669584]  write_threads+0xb8/0x16c [nfsd]
[   65.674099]  nfsctl_transaction_write+0x58/0xac [nfsd]
[   65.679437]  vfs_write+0xd4/0x3e8
[   65.682766]  ksys_write+0x70/0x108
[   65.686173]  __arm64_sys_write+0x1c/0x28
[   65.690102]  invoke_syscall+0x48/0x110
[   65.693866]  el0_svc_common.constprop.0+0x40/0xe0
[   65.698576]  do_el0_svc+0x1c/0x28
[   65.701896]  el0_svc+0x34/0xf0
[   65.704958]  el0t_64_sync_handler+0x100/0x12c
[   65.709318]  el0t_64_sync+0x1a4/0x1a8
[   65.712992] Code: 9568b8a0 f9009a7f 2a1703f6 17ffffed (d4210000)
[   65.719083] ---[ end trace 0000000000000000 ]---
[   65.723697] note: rpc.nfsd[12137] exited with irqs disabled
[   65.733055] ------------[ cut here ]------------
[   65.737704] WARNING: CPU: 3 PID: 0 at kernel/context_tracking.c:128 ct_kernel_exit.constprop.0+0x98/0xa0
[   65.747194] Modules linked in: fast_classifier shortcut_fe_cm sch_pie ath9k ath9k_common rtw88_8822cu rtw88_8822c rtw88_8822bu rtw88_8822b rtw88_8821cu rtw88_8821c rtl8192cu rtl8192c_common rtl_usb rt2800usb rt2800lib rt2500usb pppoe ppp_async mt7921u mt7921e mt7921_common mt76x0u mt76x0_common l2tp_ppp iwlmvm iwldvm carl9170 ath9k_hw ath5k ath11k_pci ath11k ath10k_pci ath10k_core ath snd_usb_audio rtw88_usb rtw88_core rtlwifi rt2x00usb rt2x00lib rsi_usb rsi_91x rndis_host rfcomm pppox ppp_mppe ppp_generic nft_fib_inet nf_flow_table_inet mt792x_usb mt792x_lib mt76x2u mt76x2_common mt76x02_usb mt76x02_lib mt7663u mt7663_usb_sdio_common mt7615_common mt7601u mt76_usb mt76_connac_lib mt76 mac80211 iwlwifi ipt_REJECT hidp hci_uart ebtable_nat ebtable_filter ebtable_broute cfg80211 cdc_ether btusb btrtl btrsi btqca btmtk btintel btbcm br_netfilter bnep bluetooth ax88179_178a xt_u32 xt_time xt_tcpudp xt_tcpmss xt_string xt_statistic xt_state xt_socket xt_recent xt_quota xt_policy xt_pkttype xt_physdev xt_owner xt_nat
[   65.747433]  xt_multiport xt_mark xt_mac xt_limit xt_length xt_iprange xt_hl xt_helper xt_hashlimit xt_esp xt_ecn xt_dscp xt_conntrack xt_connmark xt_connlimit xt_connlabel xt_connbytes xt_comment xt_cluster xt_cgroup xt_bpf xt_addrtype xt_TRACE xt_TPROXY xt_TEE xt_TCPMSS xt_REDIRECT xt_NFQUEUE xt_NFLOG xt_NETMAP xt_MASQUERADE xt_LOG xt_LED xt_HL xt_FULLCONENAT xt_FLOWOFFLOAD xt_DSCP xt_CT xt_CLASSIFY xt_CHECKSUM wireguard usbnet usblp usb_wwan ums_usbat ums_sddr55 ums_sddr09 ums_karma ums_jumpshot ums_isd200 ums_freecom ums_datafab ums_cypress ums_alauda ts_fsm ts_bm tcp_bbr sunxi_wdt snd_usbmidi_lib slhc rfkill r8152 qrtr_mhi qrtr qmi_helpers nft_reject_ipv6 nft_reject_ipv4 nft_reject_inet nft_reject_bridge nft_reject nft_redir nft_quota nft_queue nft_numgen nft_nat nft_meta_bridge nft_masq nft_log nft_limit nft_hash nft_fwd_netdev nft_flow_offload nft_fib_ipv6 nft_fib_ipv4 nft_fib nft_dup_netdev nft_ct nft_chain_nat nfnetlink_queue nfnetlink_log nf_tproxy_ipv6 nf_tproxy_ipv4 nf_tables nf_socket_ipv6 nf_socket_ipv4
[   65.837050]  nf_reject_ipv4 nf_nat_tftp nf_nat_snmp_basic nf_nat_sip nf_nat_pptp nf_nat_irc nf_nat_h323 nf_nat_ftp nf_nat_amanda nf_log_syslog nf_flow_table nf_dup_netdev nf_dup_ipv6 nf_dup_ipv4 nf_conntrack_tftp nf_conntrack_snmp nf_conntrack_sip nf_conntrack_pptp nf_conntrack_netlink nf_conntrack_irc nf_conntrack_h323 nf_conntrack_ftp nf_conntrack_broadcast nf_conntrack_bridge ts_kmp nf_conntrack_amanda nf_conncount mhi macvlan iptable_raw iptable_nat iptable_mangle iptable_filter ipt_rpfilter ipt_ah ipt_ECN ip6table_raw ip6t_rpfilter ip_tables ebtables ebt_vlan ebt_stp ebt_snat ebt_redirect ebt_pkttype ebt_nflog ebt_mark_m ebt_mark ebt_log ebt_limit ebt_ip6 ebt_ip ebt_dnat ebt_arpreply ebt_arp ebt_among ebt_802_3 e1000e cordic cdc_acm bridge ax88796b arptable_filter arpt_mangle arp_tables ntfs3 sch_teql sch_sfq sch_multiq sch_gred sch_fq sch_codel em_text em_nbyte em_meta em_cmp act_skbmod act_simple act_pedit act_csum act_connmark sch_tbf sch_ingress sch_htb sch_hfsc em_u32 cls_u32 cls_route cls_matchall cls_fw
[   65.927178]  cls_flow cls_basic act_skbedit act_mirred act_gact gpio_beeper xt_set ip_set_list_set ip_set_hash_netportnet ip_set_hash_netport ip_set_hash_netnet ip_set_hash_netiface ip_set_hash_net ip_set_hash_mac ip_set_hash_ipportnet ip_set_hash_ipportip ip_set_hash_ipport ip_set_hash_ipmark ip_set_hash_ipmac ip_set_hash_ip ip_set_bitmap_port ip_set_bitmap_ipmac ip_set_bitmap_ip ip_set nfnetlink ip6table_nat nf_nat ip6t_NPT ip6t_rt ip6t_mh ip6t_ipv6header ip6t_hbh ip6t_frag ip6t_eui64 ip6t_ah ip6table_mangle ip6table_filter ip6_tables ip6t_REJECT x_tables nf_reject_ipv6 nfsv4 nfsv3 nfsd nfs_acl nfs bonding tls ip_gre gre ifb dummy l2tp_netlink l2tp_core rpcsec_gss_krb5 auth_rpcgss veth tun snd_rawmidi snd_hwdep udf lockd sunrpc grace isofs hfsplus hfs cdrom cifs nls_ucs2_utils netfs cifs_md4 cifs_arc4 dns_resolver vxlan shortcut_fe_ipv6 shortcut_fe uhci_hcd fsl_mph_dr_of ehci_fsl dm_mirror dm_region_hash dm_log dm_crypt dm_mod ohci_platform sunxi xhci_sunxi ohci_hcd phy_generic
[   66.103761] CPU: 3 UID: 0 PID: 0 Comm: swapper/3 Tainted: G      D            6.12.12-flippy-93+ #6
[   66.112816] Tainted: [D]=DIE
[   66.115698] Hardware name: V-Plus Cloud (DT)
[   66.119967] pstate: 200000c5 (nzCv daIF -PAN -UAO -TCO -DIT -SSBS BTYPE=--)
[   66.126924] pc : ct_kernel_exit.constprop.0+0x98/0xa0
[   66.131985] lr : ct_idle_enter+0x10/0x1c
[   66.135913] sp : ffff80008242bdd0
[   66.139228] x29: ffff80008242bdd0 x28: 0000000000000000 x27: 0000000000000000
[   66.146365] x26: ffff000002a11080 x25: 0000000000000000 x24: 0000000000000000
[   66.153499] x23: 00000000000000c0 x22: ffff800081ebec30 x21: ffff000002a11080
[   66.160633] x20: ffff800081ebebe8 x19: ffff0000bffa9d40 x18: 0000000000000000
[   66.167768] x17: 0000000000000121 x16: 0000000000000000 x15: 0000000000000000
[   66.174903] x14: 0000000000000000 x13: 0000000000000000 x12: 0000000000000002
[   66.182036] x11: 0000000000000095 x10: 00000000000009f0 x9 : ffff80008242bd40
[   66.189169] x8 : ffff000002a11ad0 x7 : 000000000001d400 x6 : 000000001075b2d9
[   66.196315] x5 : 4000000000000002 x4 : ffff80003e128000 x3 : ffff80008242bdd0
[   66.203461] x2 : 4000000000000000 x1 : ffff800081e81d40 x0 : ffff800081e81d40
[   66.210596] Call trace:
[   66.213045]  ct_kernel_exit.constprop.0+0x98/0xa0
[   66.217758]  ct_idle_enter+0x10/0x1c
[   66.221347]  default_idle_call+0x20/0xec
[   66.225303]  do_idle+0x1d8/0x204
[   66.228559]  cpu_startup_entry+0x34/0x3c
[   66.232487]  secondary_start_kernel+0x128/0x140
[   66.237024]  __secondary_switched+0xb8/0xbc
[   66.241213] ---[ end trace 0000000000000000 ]---
Therefore, the client tracking mechanism of NFSv4 needs to be changed, that is, to use UMH upcall client tracking instead of legacy client tracking, and nfs-utils needs to enable nfsdcld.

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
