### PR TITLE
openssh: update to 9.9p1

### DIFF
--- a/libs/libgpiod/Makefile
+++ b/libs/libgpiod/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libgpiod
-PKG_VERSION:=1.6.4
+PKG_VERSION:=1.6.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/software/libs/libgpiod/
-PKG_HASH:=7b146e12f28fbca3df7557f176eb778c5ccf952ca464698dba8a61b2e1e3f9b5
+PKG_HASH:=ae280f697bf035a1fb780c9972e5c81d0d2712b7ab6124fb3fba24619daa72bc
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 PKG_LICENSE:=LGPL-2.1-or-later

--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssh
-PKG_VERSION:=9.3p1
+PKG_VERSION:=9.9p1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \
 		https://ftp.spline.de/pub/OpenBSD/OpenSSH/portable/
-PKG_HASH:=e9baba7701a76a51f3d85a62c383a3c9dcd97fa900b859bc7db114c1868af8a8
+PKG_HASH:=b343fbcdbff87f15b1986e6e15d6d4fc9a7d36066be6b7fb507087ba8f966c02
 
 PKG_LICENSE:=BSD ISC
 PKG_LICENSE_FILES:=LICENCE
@@ -229,6 +229,8 @@ define Package/openssh-server/install
 	$(INSTALL_BIN) ./files/sshd.failsafe $(1)/lib/preinit/99_10_failsafe_sshd
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/sshd $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/sshd-session $(1)/usr/lib/
 endef
 
 define Package/openssh-server-pam/install

--- a/net/openssh/patches/0001-build-construct_utmp-when-USE_BTMP-is-set.patch
+++ b/net/openssh/patches/0001-build-construct_utmp-when-USE_BTMP-is-set.patch
@@ -1,0 +1,22 @@
+diff --git a/loginrec.c b/loginrec.c
+index 45f13dee8b1f..7b1818b86753 100644
+--- a/loginrec.c
++++ b/loginrec.c
+@@ -614,7 +614,7 @@ line_abbrevname(char *dst, const char *src, int dstsize)
+  ** into account.
+  **/
+
+-#if defined(USE_UTMP) || defined (USE_WTMP) || defined (USE_LOGIN)
++#if defined(USE_BTMP) || defined(USE_UTMP) || defined (USE_WTMP) || defined (USE_LOGIN)
+
+ /* build the utmp structure */
+ void
+@@ -698,7 +698,7 @@ construct_utmp(struct logininfo *li,
+ 	}
+ # endif
+ }
+-#endif /* USE_UTMP || USE_WTMP || USE_LOGIN */
++#endif /* USE_BTMP || USE_UTMP || USE_WTMP || USE_LOGIN */
+
+ /**
+  ** utmpx utility functions


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (aarch64, phicomm N1, tests done)
```
root@OP_N1:~# sshd -version
sshd: unrecognized option: v
OpenSSH_9.9p1, OpenSSL 3.0.15 3 Sep 2024
usage: sshd [-46DdeGiqTtV] [-C connection_spec] [-c host_cert_file]
            [-E log_file] [-f config_file] [-g login_grace_time]
            [-h host_key_file] [-o option] [-p port] [-u len]
root@OP_N1:~# 
```