### PR TITLE
softethervpn5 remove region restriction

### DIFF
--- a/net/softethervpn5/patches/120-remove-region-restriction.patch
+++ b/net/softethervpn5/patches/120-remove-region-restriction.patch
@@ -1,0 +1,12 @@
+diff --git a/src/Cedar/Server.c b/src/Cedar/Server.c
+index 1aad0d94..0eba8bfc 100644
+--- a/src/Cedar/Server.c
++++ b/src/Cedar/Server.c
+@@ -10749,6 +10749,7 @@ void SiGetCurrentRegion(CEDAR *c, char *region, UINT region_size)
+ // 
+ bool SiIsEnterpriseFunctionsRestrictedOnOpenSource(CEDAR *c)
+ {
++	return false;
+ 	char region[128];
+ 	bool ret = false;
+ 	// Validate arguments


### PR DESCRIPTION
移除softethervpn5中针对China/Japan地区的企业功能限制

Maintainer: @parkycai 
Compile tested: x86_64
Run tested: x86_64

Description:
已测试通过