### PR TITLE
nft-qos: fix monitor duplicates

### DIFF
--- a/net/nft-qos/files/lib/monitor.sh
+++ b/net/nft-qos/files/lib/monitor.sh
@@ -6,7 +6,7 @@
 . /lib/nft-qos/core.sh
 
 qosdef_monitor_get_ip_handle() { # <family> <chain> <ip>
-	echo $(nft list chain $1 nft-qos-monitor $2 -a 2>/dev/null | grep $3 | awk '{print $11}')
+	echo $(nft -a list chain $1 nft-qos-monitor $2 2>/dev/null | grep $3 | awk '{print $11}')
 }
 
 qosdef_monitor_add() { # <mac> <ip> <hostname>


### PR DESCRIPTION
修复了 nft-qos 可能重复添加规则的问题