### PR TITLE
fix ramips compile error

### DIFF
--- a/utils/v2dat/Makefile
+++ b/utils/v2dat/Makefile
@@ -22,6 +22,8 @@ PKG_MAINTAINER:=sbwml <admin@cooluc.com>
 
 PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+PKG_BUILD_FLAGS:=no-mips16
 
 GO_PKG:=github.com/urlesistiana/v2dat
 


### PR DESCRIPTION
fix ramips compile error likes:"invalid operands"

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:修复ramips平台编译v2dat出现“无效操作数”的问题
