### PR TITLE
adguardhome: Bump to 0.107.63

### DIFF
--- a/net/adguardhome/Makefile
+++ b/net/adguardhome/Makefile
@@ -6,43 +6,46 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adguardhome
-PKG_VERSION:=0.107.61
+PKG_VERSION:=0.107.63
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/AdGuardHome/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=da0cc5f3d1bd0e374bfd72dfb1846c7f0b1a172f176d20526da5eb57631b9521
+PKG_HASH:=f445eb98fc1beba326433da7c999799fe36c7f15297fdebe59a41914eaffe3ad
 PKG_BUILD_DIR:=$(BUILD_DIR)/AdGuardHome-$(PKG_VERSION)
+
+FRONTEND_DEST:=$(PKG_NAME)-frontend-$(PKG_VERSION).tar.gz
+FRONTEND_URL:=https://github.com/AdguardTeam/AdGuardHome/releases/download/v$(PKG_VERSION)/
+FRONTEND_HASH:=74bda6f7c7334342b33fff50a0cdff4e206f84a471bab983ee16d3f6f112c53a
 
 PKG_LICENSE:=GPL-3.0-only
 PKG_LICENSE_FILES:=LICENSE.txt
 PKG_CPE_ID:=cpe:/a:adguard:adguardhome
-PKG_MAINTAINER:=Dobroslaw Kijowski <dobo90@gmail.com>
+PKG_MAINTAINER:=Dobroslaw Kijowski <dobo90@gmail.com>, George Sapkin <george@sapk.in>
 
 PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1
-PKG_USE_MIPS16:=0
+PKG_BUILD_FLAGS:=no-mips16
 
 GO_PKG:=github.com/AdguardTeam/AdGuardHome
 GO_PKG_BUILD_PKG:=$(GO_PKG)
 
-AGH_VERSION_PKG:=$(GO_PKG)/internal/version
 GO_PKG_LDFLAGS_X:= \
-	$(AGH_VERSION_PKG).channel=release \
-	$(AGH_VERSION_PKG).version=$(PKG_VERSION) \
-	$(AGH_VERSION_PKG).committime=$(SOURCE_DATE_EPOCH) \
-	$(AGH_VERSION_PKG).goarm=$(GO_ARM) \
-	$(AGH_VERSION_PKG).gomips=$(GO_MIPS)
+	$(GO_PKG)/internal/version.channel=release \
+	$(GO_PKG)/internal/version.version=v$(PKG_VERSION) \
+	$(GO_PKG)/internal/version.committime=$(SOURCE_DATE_EPOCH) \
+	$(GO_PKG)/internal/version.goarm=$(GO_ARM) \
+	$(GO_PKG)/internal/version.gomips=$(GO_MIPS)
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
 
 define Package/adguardhome
-	SECTION:=net
-	CATEGORY:=Network
-	TITLE:=Network-wide ads and trackers blocking DNS server
-	URL:=https://github.com/AdguardTeam/AdGuardHome
-	DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Network-wide ads and trackers blocking DNS server
+  URL:=https://github.com/AdguardTeam/AdGuardHome
+  DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle
 endef
 
 define Package/adguardhome/conffiles
@@ -51,21 +54,20 @@ define Package/adguardhome/conffiles
 endef
 
 define Package/adguardhome/description
-	Free and open source, powerful network-wide ads and trackers blocking DNS server.
+  Free and open source, powerful network-wide ads and trackers blocking DNS server.
 endef
 
-FRONTEND_FILE:=$(PKG_NAME)_frontend-$(PKG_VERSION).tar.gz
-define Download/adguardhome_frontend
-	URL:=https://github.com/AdguardTeam/AdGuardHome/releases/download/v$(PKG_VERSION)/
+define Download/adguardhome-frontend
+	URL:=$(FRONTEND_URL)
 	URL_FILE:=AdGuardHome_frontend.tar.gz
-	FILE:=$(FRONTEND_FILE)
-	HASH:=69ff3444f06d9c872f38af5b1a90bfd2438bb278fc7aa654f2e72d92835aee7b
+	FILE:=$(FRONTEND_DEST)
+	HASH:=$(FRONTEND_HASH)
 endef
 
 define Build/Prepare
 	$(call Build/Prepare/Default)
 
-	gzip -dc $(DL_DIR)/$(FRONTEND_FILE) | $(HOST_TAR) -C $(PKG_BUILD_DIR)/ $(TAR_OPTIONS)
+	gzip -dc $(DL_DIR)/$(FRONTEND_DEST) | $(HOST_TAR) -C $(PKG_BUILD_DIR)/ $(TAR_OPTIONS)
 endef
 
 define Package/adguardhome/install
@@ -80,6 +82,6 @@ define Package/adguardhome/install
 	$(INSTALL_CONF) ./files/adguardhome.sysctl $(1)/etc/sysctl.d/50-adguardhome.conf
 endef
 
-$(eval $(call Download,adguardhome_frontend))
+$(eval $(call Download,adguardhome-frontend))
 $(eval $(call GoBinPackage,adguardhome))
 $(eval $(call BuildPackage,adguardhome))


### PR DESCRIPTION
可以正常使用

<img width="771" height="481" alt="image" src="https://github.com/user-attachments/assets/f6a0fc89-67e2-475d-b1cb-964ed9d50bd7" />
<img width="738" height="459" alt="image" src="https://github.com/user-attachments/assets/2a5098db-3979-4cb4-9af5-dd0dcf734b36" />