### PR TITLE
rclone: Update to 1.72.1

### DIFF
--- a/net/rclone/Makefile
+++ b/net/rclone/Makefile
@@ -6,17 +6,18 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rclone
-PKG_VERSION:=1.69.0
+PKG_VERSION:=1.72.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/rclone/rclone/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=9b360793108d0b9a3208dacece76e72f5d9253c6710da1c08a1eb8a91eeb9854
+PKG_HASH:=322c73932b533571880832c0e07abdf9492c7f329b7d1dcdbd2a195fa2635a77
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Elon Huang <elonhhuang@gmail.com> \
 		Tianling Shen <cnsztl@immortalwrt.org>
+PKG_CPE_ID:=cpe:/a:rclone:rclone
 
 PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1

--- a/net/rclone/files/rclone.init
+++ b/net/rclone/files/rclone.init
@@ -92,11 +92,6 @@ start_service() {
 	procd_close_instance
 }
 
-reload_service() {
-	stop
-	start
-}
-
 service_triggers() {
 	procd_add_reload_trigger "rclone"
 }


### PR DESCRIPTION
Release note: https://github.com/rclone/rclone/releases/tag/v1.72.1

Assign PKG_CPE_ID to enhance CVE coverage.
